### PR TITLE
fix: harden step execution, LLM client, and config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ Datamatic outputs structured data in JSONl format:
 
 ```go
 type LineEntity struct {
-	ID       string      `json:"id"`
-	Format   string      `json:"format"`
-	Prompt   string      `json:"prompt"`
-	Response interface{} `json:"response"`
-	Values   interface{} `json:"values"`
+	ID       string                              `json:"id"`
+	Format   string                              `json:"format"`
+	Prompt   string                              `json:"prompt"`
+	Response interface{}                         `json:"response"`
+	Values   map[string]promptbuilder.ValueShort `json:"values,omitempty"`
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ const (
 )
 
 type Step struct {
-	Type               StepType
+	Type               StepType    `yaml:"type,omitempty"`
 	Name               string      `yaml:"name"`
 	Model              string      `yaml:"model"`
 	Prompt             string      `yaml:"prompt"`

--- a/config/validate.go
+++ b/config/validate.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mirpo/datamatic/promptbuilder"
 	"github.com/mirpo/datamatic/retry"
+	"github.com/rs/zerolog/log"
 )
 
 func validateVersion(version string) error {
@@ -38,8 +40,8 @@ func validateURL(input string) error {
 
 func validateModelConfig(step ModelConfig) error {
 	if step.Temperature != nil {
-		if *step.Temperature < 0 || *step.Temperature > 1 {
-			return errors.New("temperature must be between 0 and 1")
+		if *step.Temperature < 0 || *step.Temperature > 2 {
+			return errors.New("temperature must be between 0 and 2")
 		}
 	}
 
@@ -131,8 +133,8 @@ func (c *Config) Validate() error {
 
 			filename := filepath.Base(step.OutputFilename)
 			if !strings.Contains(step.Run, filename) {
-				return fmt.Errorf("step '%s': output filename should match output result of external shell command; run: [%s], output file: %s",
-					step.Name, step.Run, filename)
+				log.Warn().Msgf("step '%s': output filename '%s' not found in run command — make sure the command actually creates this file",
+					step.Name, filename)
 			}
 		}
 
@@ -140,6 +142,9 @@ func (c *Config) Validate() error {
 			if step.JSONSchema.HasSchemaDefinition() {
 				if err := step.JSONSchema.EnsureAllPropertiesRequired(); err != nil {
 					return fmt.Errorf("step '%s': %w", step.Name, err)
+				}
+				for _, issue := range step.JSONSchema.StrictCompatibilityIssues() {
+					log.Warn().Msgf("step '%s': schema is not strict-mode compatible (may be rejected by OpenAI): %s", step.Name, issue)
 				}
 			}
 
@@ -191,7 +196,7 @@ func (c *Config) Validate() error {
 	}
 
 	if !c.SkipCliWarning && len(cliCalls) > 0 {
-		fmt.Printf("⚠️ WARNING: External application call detected! The author assumes no responsibility for execution results. Please verify all external calls before proceeding. Use at your own risk.\n\nCalls: \n%s\n\nPress Enter to continue", strings.Join(cliCalls, "\n"))
+		fmt.Fprintf(os.Stderr, "⚠️ WARNING: External application call detected! The author assumes no responsibility for execution results. Please verify all external calls before proceeding. Use at your own risk.\n\nCalls: \n%s\n\nPress Enter to continue", strings.Join(cliCalls, "\n"))
 		fmt.Scanln() //nolint:golint,errcheck
 	}
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -41,8 +41,10 @@ func TestValidateUrl(t *testing.T) {
 func TestValidateModelConfig(t *testing.T) {
 	temp0_5 := 0.5
 	temp1_0 := 1.0
+	temp1_5 := 1.5
+	temp2_0 := 2.0
 	tempNeg := -0.1
-	tempOver := 1.1
+	tempOver := 2.1
 
 	maxTokens100 := 100
 	maxTokensNeg := -1
@@ -56,9 +58,11 @@ func TestValidateModelConfig(t *testing.T) {
 	}{
 		{"Valid Mid", ModelConfig{Temperature: &temp0_5, MaxTokens: &maxTokens100, BaseURL: "http://example.com"}, false, ""},
 		{"Valid Max", ModelConfig{Temperature: &temp1_0, MaxTokens: &maxTokensLarge, BaseURL: "https://test.org/api"}, false, ""},
+		{"Valid Above 1 (OpenAI range)", ModelConfig{Temperature: &temp1_5, MaxTokens: &maxTokens100}, false, ""},
+		{"Valid Upper Bound 2.0", ModelConfig{Temperature: &temp2_0, MaxTokens: &maxTokens100}, false, ""},
 		{"Valid Nil Temp", ModelConfig{Temperature: nil, MaxTokens: &maxTokens100, BaseURL: ""}, false, ""},
-		{"Invalid Temp Below 0", ModelConfig{Temperature: &tempNeg, MaxTokens: &maxTokens100}, true, "temperature must be between 0 and 1"},
-		{"Invalid Temp Above 1", ModelConfig{Temperature: &tempOver, MaxTokens: &maxTokens100}, true, "temperature must be between 0 and 1"},
+		{"Invalid Temp Below 0", ModelConfig{Temperature: &tempNeg, MaxTokens: &maxTokens100}, true, "temperature must be between 0 and 2"},
+		{"Invalid Temp Above 2", ModelConfig{Temperature: &tempOver, MaxTokens: &maxTokens100}, true, "temperature must be between 0 and 2"},
 		{"Invalid MaxTokens Negative", ModelConfig{Temperature: &temp0_5, MaxTokens: &maxTokensNeg}, true, "maxTokens must be > 0"},
 		{"Invalid BaseUrl", ModelConfig{Temperature: &temp0_5, MaxTokens: &maxTokens100, BaseURL: "not a url"}, true, "invalid baseUrl"},
 	}
@@ -137,7 +141,7 @@ func TestValidateConfig(t *testing.T) {
 		cfg.Steps[0].ModelConfig.Temperature = &tempNeg
 		err := cfg.Validate()
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "step 'step1': model config validation failed: temperature must be between 0 and 1")
+		assert.Contains(t, err.Error(), "step 'step1': model config validation failed: temperature must be between 0 and 2")
 	})
 
 	t.Run("MaxResults Defaults Correctly", func(t *testing.T) {
@@ -238,23 +242,23 @@ func TestCLIFilenameValidation_PostPreprocessing(t *testing.T) {
 		assert.NoError(t, err, "Should pass because full path matches exactly")
 	})
 
-	t.Run("Shell step without filename in command fails", func(t *testing.T) {
+	t.Run("Shell step without filename in command warns but passes", func(t *testing.T) {
 		cfg := &Config{
-			Version:     "1.0",
-			RetryConfig: retry.NewDefaultConfig(),
+			Version:        "1.0",
+			RetryConfig:    retry.NewDefaultConfig(),
+			SkipCliWarning: true,
 			Steps: []Step{
 				{
 					Name:           "download_only",
 					Type:           ShellStepType,
-					Run:            `curl -o different_name.json https://api.example.com/data`,
+					Run:            `./scripts/fetch.sh`, // writes expected.json internally
 					OutputFilename: "/abs/path/to/output/expected.json",
 				},
 			},
 		}
 
 		err := cfg.Validate()
-		assert.Error(t, err, "Should fail because neither 'expected.json' nor full path is in command")
-		assert.Contains(t, err.Error(), "output filename should match output result of external shell")
+		assert.NoError(t, err, "filename-in-command is a heuristic; must warn, not fail")
 	})
 }
 

--- a/datamatic.go
+++ b/datamatic.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/goforj/godump"
 	"github.com/mirpo/datamatic/config"
@@ -24,13 +27,13 @@ func main() {
 
 	var ver bool
 	flag.BoolVar(&ver, "version", false, "Get current version of datamatic")
-	flag.BoolVar(&cfg.Verbose, "verbose", false, "Enable DEBUG logging level")
-	flag.BoolVar(&cfg.LogPretty, "log-pretty", true, "Enable pretty logging, JSON when false")
-	flag.StringVar(&cfg.ConfigFile, "config", "", "Config file path")
-	flag.StringVar(&cfg.OutputFolder, "output", "dataset", "Output folder path")
-	flag.IntVar(&cfg.HTTPTimeout, "http-timeout", 300, "HTTP timeout: 0 - no timeout, if number - recommended to put high on poor hardware")
-	flag.BoolVar(&cfg.ValidateResponse, "validate-response", true, "Validate JSON response from server to match the schema")
-	flag.BoolVar(&cfg.SkipCliWarning, "skip-cli-warning", false, "Skip external CLI warning")
+	flag.BoolVar(&cfg.Verbose, "verbose", cfg.Verbose, "Enable DEBUG logging level")
+	flag.BoolVar(&cfg.LogPretty, "log-pretty", cfg.LogPretty, "Enable pretty logging, JSON when false")
+	flag.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "Config file path")
+	flag.StringVar(&cfg.OutputFolder, "output", cfg.OutputFolder, "Output folder path")
+	flag.IntVar(&cfg.HTTPTimeout, "http-timeout", cfg.HTTPTimeout, "HTTP timeout: 0 - no timeout, if number - recommended to put high on poor hardware")
+	flag.BoolVar(&cfg.ValidateResponse, "validate-response", cfg.ValidateResponse, "Validate JSON response from server to match the schema")
+	flag.BoolVar(&cfg.SkipCliWarning, "skip-cli-warning", cfg.SkipCliWarning, "Skip external CLI warning")
 
 	flag.Parse()
 
@@ -86,9 +89,11 @@ func main() {
 		godump.Dump(cfg)
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	r := runner.NewRunner(cfg)
-	if err := r.Run(); err != nil {
+	if err := r.Run(ctx); err != nil {
 		log.Fatal().Err(err).Msg("failed to execute runner")
-		os.Exit(1)
 	}
 }

--- a/fs/reader.go
+++ b/fs/reader.go
@@ -5,33 +5,37 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
+
+	"github.com/rs/zerolog/log"
 )
 
+// lineCountCache caches line counts per path. Safe because step outputs are
+// immutable once the producing step completes and steps run sequentially.
+var lineCountCache sync.Map // path -> int
+
 func ReadLineFromFile(path string, lineNumber int) (string, error) {
-	file, err := os.Open(path)
+	lineCount, err := cachedLineCount(path)
 	if err != nil {
 		return "", err
-	}
-	defer file.Close()
-
-	var lineCount int
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lineCount++
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning file to count lines: %w", err)
 	}
 	if lineCount == 0 {
 		return "", errors.New("file is empty")
 	}
 
 	effectiveIndex := normalizeIndex(lineNumber, lineCount)
-
-	if _, err := file.Seek(0, 0); err != nil {
-		return "", fmt.Errorf("error seeking to start of file: %w", err)
+	if effectiveIndex != lineNumber {
+		log.Warn().Msgf("requested line %d but '%s' has only %d lines — wrapping to line %d (check for data misalignment)",
+			lineNumber, path, lineCount, effectiveIndex)
 	}
-	scanner = bufio.NewScanner(file)
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
 	for i := 0; scanner.Scan(); i++ {
 		if i == effectiveIndex {
 			return scanner.Text(), nil
@@ -42,6 +46,20 @@ func ReadLineFromFile(path string, lineNumber int) (string, error) {
 	}
 
 	return "", errors.New("unexpected error: target line not found")
+}
+
+func cachedLineCount(path string) (int, error) {
+	if v, ok := lineCountCache.Load(path); ok {
+		return v.(int), nil
+	}
+
+	count, err := CountLinesInFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	lineCountCache.Store(path, count)
+	return count, nil
 }
 
 func normalizeIndex(index, length int) int {

--- a/fs/reader_test.go
+++ b/fs/reader_test.go
@@ -1,10 +1,14 @@
 package fs
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeIndex(t *testing.T) {
@@ -84,7 +88,7 @@ func TestReadLineFromFile_EmptyFile(t *testing.T) {
 func TestReadLineFromFile_FileNotExist(t *testing.T) {
 	_, err := ReadLineFromFile("non_existent_file.txt", 0)
 	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err), "Expected 'file not exist' error, but got: %v", err)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "Expected 'file not exist' error, but got: %v", err)
 }
 
 func TestCountLinesInFile(t *testing.T) {
@@ -113,5 +117,16 @@ func TestCountLinesInFile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, count)
 		})
+	}
+}
+
+func TestReadLineFromFile_RepeatedReadsStayCorrect(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("l0\nl1\nl2\n"), 0o644))
+
+	for i := range 10 {
+		line, err := ReadLineFromFile(path, i)
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("l%d", i%3), line)
 	}
 }

--- a/internal/llmtest/server.go
+++ b/internal/llmtest/server.go
@@ -1,0 +1,86 @@
+// Package llmtest provides a mock OpenAI-compatible chat-completions server for tests.
+package llmtest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+type Server struct {
+	URL   string
+	Delay time.Duration // set before first request; simulates a slow server
+
+	server    *httptest.Server
+	mu        sync.Mutex
+	responses []string
+	requests  []map[string]interface{}
+}
+
+// NewServer returns a mock chat-completions server that answers with the given
+// message contents in order; the last response repeats for extra calls.
+func NewServer(t *testing.T, responses ...string) *Server {
+	t.Helper()
+	s := &Server{responses: responses}
+
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.Delay > 0 {
+			select {
+			case <-time.After(s.Delay):
+			case <-r.Context().Done():
+				return // client gave up; don't hold server shutdown
+			}
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+
+		s.mu.Lock()
+		s.requests = append(s.requests, req)
+		idx := len(s.requests) - 1
+		if idx >= len(s.responses) {
+			idx = len(s.responses) - 1
+		}
+		content := s.responses[idx]
+		s.mu.Unlock()
+
+		model, _ := req["model"].(string)
+		resp := map[string]interface{}{
+			"id":     "mock",
+			"object": "chat.completion",
+			"model":  model,
+			"choices": []map[string]interface{}{
+				{
+					"index":         0,
+					"finish_reason": "stop",
+					"message":       map[string]interface{}{"role": "assistant", "content": content},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(s.server.Close)
+
+	s.URL = s.server.URL
+	return s
+}
+
+func (s *Server) CallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+// Requests returns the decoded JSON bodies of all received requests.
+func (s *Server) Requests() []map[string]interface{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]map[string]interface{}(nil), s.requests...)
+}

--- a/internal/llmtest/server_test.go
+++ b/internal/llmtest/server_test.go
@@ -1,0 +1,45 @@
+package llmtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func post(t *testing.T, url, body string) map[string]interface{} {
+	t.Helper()
+	resp, err := http.Post(url+"/chat/completions", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&decoded))
+	return decoded
+}
+
+func TestServer_ScriptedResponsesAndCapture(t *testing.T) {
+	srv := NewServer(t, "first", "second")
+
+	resp1 := post(t, srv.URL, `{"model":"m1","temperature":0.5}`)
+	resp2 := post(t, srv.URL, `{"model":"m1"}`)
+	resp3 := post(t, srv.URL, `{"model":"m1"}`) // last response repeats
+
+	content := func(r map[string]interface{}) string {
+		choices := r["choices"].([]interface{})
+		msg := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+		return msg["content"].(string)
+	}
+
+	assert.Equal(t, "first", content(resp1))
+	assert.Equal(t, "second", content(resp2))
+	assert.Equal(t, "second", content(resp3))
+
+	assert.Equal(t, 3, srv.CallCount())
+	require.Len(t, srv.Requests(), 3)
+	assert.Equal(t, 0.5, srv.Requests()[0]["temperature"])
+	assert.Equal(t, "m1", resp1["model"], "echoes request model to avoid mismatch warnings")
+}

--- a/jsonl/line.go
+++ b/jsonl/line.go
@@ -17,15 +17,14 @@ type LineEntity struct {
 }
 
 func cleanResponse(input string) string {
-	input = strings.TrimPrefix(input, "\"")
-	input = strings.TrimSuffix(input, "\"")
-
-	input = strings.TrimPrefix(input, "```json")
-	input = strings.TrimPrefix(input, "```")
-
-	input = strings.TrimSuffix(input, "```")
-
 	input = strings.TrimSpace(input)
+
+	if strings.HasPrefix(input, "```") {
+		input = strings.TrimPrefix(input, "```json")
+		input = strings.TrimPrefix(input, "```")
+		input = strings.TrimSuffix(strings.TrimSpace(input), "```")
+		input = strings.TrimSpace(input)
+	}
 
 	return input
 }
@@ -47,7 +46,7 @@ func NewLineEntity(response string, prompt string, isJSON bool, values map[strin
 
 	return LineEntity{
 		ID:       uuid.New().String(),
-		Prompt:   cleanResponse(prompt),
+		Prompt:   strings.TrimSpace(prompt),
 		Response: parsedResponse,
 		Format:   format,
 		Values:   values,

--- a/jsonl/line_test.go
+++ b/jsonl/line_test.go
@@ -20,9 +20,14 @@ func TestCleanResponse(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "removes surrounding quotes",
+			name:     "keeps surrounding quotes (legitimate content)",
 			input:    `"hello world"`,
-			expected: "hello world",
+			expected: `"hello world"`,
+		},
+		{
+			name:     "keeps inner fences when not wrapping",
+			input:    "text with ``` inside",
+			expected: "text with ``` inside",
 		},
 		{
 			name:     "removes ```json prefix and ``` suffix",
@@ -52,6 +57,16 @@ func TestCleanResponse(t *testing.T) {
 			assert.Equal(t, tt.expected, cleaned)
 		})
 	}
+}
+
+func TestNewLineEntity_PromptOnlyTrimmed(t *testing.T) {
+	prompt := "  ```json\nreturn this schema\n```  "
+
+	entity, err := NewLineEntity("response", prompt, false, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "```json\nreturn this schema\n```", entity.Prompt,
+		"prompt must only be whitespace-trimmed, never fence/quote-stripped")
 }
 
 func TestNewTextLineEntity(t *testing.T) {

--- a/jsonschema/types.go
+++ b/jsonschema/types.go
@@ -151,6 +151,40 @@ func (s *Schema) HasFieldPath(path string) bool {
 	return true
 }
 
+// StrictCompatibilityIssues walks the schema and reports paths that break
+// OpenAI strict structured-output requirements: every object level must
+// require all of its properties and set additionalProperties: false.
+func (s *Schema) StrictCompatibilityIssues() []string {
+	if !s.HasSchemaDefinition() {
+		return nil
+	}
+	var issues []string
+	walkStrict(s.schema, "$", &issues)
+	return issues
+}
+
+func walkStrict(node *jsonschema.Schema, path string, issues *[]string) {
+	if node == nil {
+		return
+	}
+
+	if node.Properties != nil {
+		for name, child := range *node.Properties {
+			if !slices.Contains(node.Required, name) {
+				*issues = append(*issues, fmt.Sprintf("%s: property %q is not required", path, name))
+			}
+			walkStrict(child, path+"."+name, issues)
+		}
+		if node.AdditionalProperties == nil || node.AdditionalProperties.Boolean == nil || *node.AdditionalProperties.Boolean {
+			*issues = append(*issues, fmt.Sprintf("%s: additionalProperties is not false", path))
+		}
+	}
+
+	if node.Items != nil {
+		walkStrict(node.Items, path+".items", issues)
+	}
+}
+
 // extractFieldByPath extracts a field from JSON data using a dot path.
 func extractFieldByPath(data interface{}, path string) (interface{}, error) {
 	if path == "" {

--- a/jsonschema/types_test.go
+++ b/jsonschema/types_test.go
@@ -2,9 +2,11 @@ package jsonschema
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadSchema(t *testing.T) {
@@ -357,4 +359,45 @@ func TestExtractFieldByPathAsString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStrictCompatibilityIssues(t *testing.T) {
+	schema, err := LoadSchema(`{
+		"type": "object",
+		"properties": {
+			"companies": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"},
+						"location": {"type": "string"}
+					},
+					"required": ["name"]
+				}
+			}
+		},
+		"required": ["companies"],
+		"additionalProperties": false
+	}`)
+	require.NoError(t, err)
+
+	issues := schema.StrictCompatibilityIssues()
+
+	assert.NotEmpty(t, issues)
+	joined := strings.Join(issues, "; ")
+	assert.Contains(t, joined, "companies.items", "must point at the offending path")
+	assert.Contains(t, joined, "location", "optional nested property must be flagged")
+}
+
+func TestStrictCompatibilityIssues_CleanSchema(t *testing.T) {
+	schema, err := LoadSchema(`{
+		"type": "object",
+		"properties": {"title": {"type": "string"}},
+		"required": ["title"],
+		"additionalProperties": false
+	}`)
+	require.NoError(t, err)
+
+	assert.Empty(t, schema.StrictCompatibilityIssues())
 }

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -3,6 +3,9 @@ package llm
 import (
 	"context"
 	"fmt"
+	"math"
+	"net/http"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/sashabaranov/go-openai"
@@ -20,6 +23,12 @@ func NewOpenAIProvider(config ProviderConfig) *OpenAIProvider {
 
 	if config.BaseURL != "" {
 		clientConfig.BaseURL = config.BaseURL
+	}
+
+	if config.HTTPTimeout > 0 {
+		clientConfig.HTTPClient = &http.Client{
+			Timeout: time.Duration(config.HTTPTimeout) * time.Second,
+		}
 	}
 
 	return &OpenAIProvider{
@@ -47,6 +56,11 @@ func (p *OpenAIProvider) Generate(ctx context.Context, request GenerateRequest) 
 
 	if p.config.Temperature != nil {
 		req.Temperature = float32(*p.config.Temperature)
+		if req.Temperature == 0 {
+			// go-openai marshals Temperature with omitempty, dropping 0;
+			// the smallest non-zero float is the documented workaround.
+			req.Temperature = math.SmallestNonzeroFloat32
+		}
 	}
 	if p.config.MaxTokens != nil {
 		req.MaxTokens = *p.config.MaxTokens

--- a/llm/openai_test.go
+++ b/llm/openai_test.go
@@ -1,0 +1,65 @@
+package llm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mirpo/datamatic/internal/llmtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_RespectsHTTPTimeout(t *testing.T) {
+	srv := llmtest.NewServer(t, "too late")
+	srv.Delay = 2 * time.Second
+
+	provider := NewOpenAIProvider(ProviderConfig{
+		BaseURL:     srv.URL,
+		ModelName:   "m",
+		HTTPTimeout: 1, // seconds
+	})
+
+	start := time.Now()
+	_, err := provider.Generate(context.Background(), GenerateRequest{UserMessage: "hi"})
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second, "must abort before server responds")
+}
+
+func TestGenerate_ZeroTimeoutMeansNoTimeout(t *testing.T) {
+	srv := llmtest.NewServer(t, "ok")
+
+	provider := NewOpenAIProvider(ProviderConfig{BaseURL: srv.URL, ModelName: "m", HTTPTimeout: 0})
+
+	resp, err := provider.Generate(context.Background(), GenerateRequest{UserMessage: "hi"})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Text)
+}
+
+func TestGenerate_TemperatureZeroIsSent(t *testing.T) {
+	srv := llmtest.NewServer(t, "ok")
+
+	temp := 0.0
+	provider := NewOpenAIProvider(ProviderConfig{BaseURL: srv.URL, ModelName: "m", Temperature: &temp})
+
+	_, err := provider.Generate(context.Background(), GenerateRequest{UserMessage: "hi"})
+	require.NoError(t, err)
+
+	req := srv.Requests()[0]
+	got, present := req["temperature"]
+	require.True(t, present, "temperature: 0 must be serialized, not dropped by omitempty")
+	assert.InDelta(t, 0.0, got.(float64), 1e-6)
+}
+
+func TestGenerate_NilTemperatureIsNotSent(t *testing.T) {
+	srv := llmtest.NewServer(t, "ok")
+
+	provider := NewOpenAIProvider(ProviderConfig{BaseURL: srv.URL, ModelName: "m"})
+
+	_, err := provider.Generate(context.Background(), GenerateRequest{UserMessage: "hi"})
+	require.NoError(t, err)
+
+	_, present := srv.Requests()[0]["temperature"]
+	assert.False(t, present)
+}

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -1,8 +1,6 @@
 package llm
 
 import (
-	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,21 +20,21 @@ func TestNewProvider(t *testing.T) {
 	})
 
 	t.Run("returns OpenAI provider", func(t *testing.T) {
-		os.Setenv("OPENAI_API_KEY", "test-key")
+		t.Setenv("OPENAI_API_KEY", "test-key")
 		provider, err := NewProvider(ProviderConfig{ProviderType: ProviderOpenAI})
 		assert.NoError(t, err)
 		assert.NotNil(t, provider)
 	})
 
 	t.Run("returns OpenRouter provider", func(t *testing.T) {
-		os.Setenv("OPENROUTER_API_KEY", "test-key")
+		t.Setenv("OPENROUTER_API_KEY", "test-key")
 		provider, err := NewProvider(ProviderConfig{ProviderType: ProviderOpenRouter})
 		assert.NoError(t, err)
 		assert.NotNil(t, provider)
 	})
 
 	t.Run("returns Gemini provider", func(t *testing.T) {
-		os.Setenv("GEMINI_API_KEY", "test-key")
+		t.Setenv("GEMINI_API_KEY", "test-key")
 		provider, err := NewProvider(ProviderConfig{ProviderType: ProviderGemini})
 		assert.NoError(t, err)
 		assert.NotNil(t, provider)
@@ -46,7 +44,6 @@ func TestNewProvider(t *testing.T) {
 		provider, err := NewProvider(ProviderConfig{ProviderType: ProviderUnknown})
 		assert.Nil(t, provider)
 		assert.Error(t, err)
-		assert.True(t, errors.Is(err, err)) // simple check, or you could check message
 		assert.Contains(t, err.Error(), "provider type 'unknown' is not supported")
 	})
 

--- a/promptbuilder/promptbuilder.go
+++ b/promptbuilder/promptbuilder.go
@@ -166,7 +166,10 @@ func (pb *PromptBuilder) GetValues() map[string]ValueShort {
 		}
 
 		for fieldPath, stepValue := range stepFields {
-			key := "." + strings.Join(append([]string{stepName}, fieldPath), ".")
+			key := "." + stepName
+			if fieldPath != "" {
+				key += "." + fieldPath
+			}
 			resultValues[key] = ValueShort{
 				ID:    stepValue.ID,
 				Value: stepValue.Content,

--- a/promptbuilder/promptbuilder_test.go
+++ b/promptbuilder/promptbuilder_test.go
@@ -242,3 +242,14 @@ func TestPromptBuilder_GetValues(t *testing.T) {
 	actual := builder.GetValues()
 	assert.Equal(t, expected, actual)
 }
+
+func TestPromptBuilder_GetValues_WholeStepReference(t *testing.T) {
+	builder := NewPromptBuilder("Test prompt.")
+	builder.AddValue("1", "generate_cv", "", "full cv text") // whole-response reference
+
+	actual := builder.GetValues()
+
+	assert.Equal(t, map[string]ValueShort{
+		".generate_cv": {ID: "1", Value: "full cv text"},
+	}, actual, "no trailing dot for whole-step references")
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -72,12 +72,16 @@ func (r *Runner) resolveMaxResults(step *config.Step) error {
 	return fmt.Errorf("unexpected MaxResults value: %v", step.MaxResults)
 }
 
-func (r *Runner) Run() error {
+func (r *Runner) Run(ctx context.Context) error {
 	if err := r.PrepareOutputDirectory(); err != nil {
 		return err
 	}
 
 	for _, stepConfig := range r.cfg.Steps {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("run cancelled: %w", err)
+		}
+
 		log.Info().Msgf("Starting step: '%s' (type: '%s')", stepConfig.Name, stepConfig.Type)
 
 		if stepConfig.Type == config.PromptStepType {
@@ -92,10 +96,10 @@ func (r *Runner) Run() error {
 			return err
 		}
 
-		err = runner.Run(context.Background(), r.cfg, stepConfig, r.cfg.OutputFolder)
+		err = runner.Run(ctx, r.cfg, stepConfig, r.cfg.OutputFolder)
 		if err != nil {
 			log.Error().Err(err).Msgf("step '%s' failed", stepConfig.Name)
-			return err
+			return fmt.Errorf("step '%s': %w", stepConfig.Name, err)
 		}
 
 		log.Info().Msgf("Completed step: %s", stepConfig.Name)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,11 +1,13 @@
 package runner_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/mirpo/datamatic/config"
+	"github.com/mirpo/datamatic/runner"
 	"github.com/mirpo/datamatic/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -62,4 +64,20 @@ func setupTestEnvVars(t *testing.T, path string) {
 			os.Unsetenv("MODEL")
 		})
 	}
+}
+
+func TestRun_CancelledContextStopsExecution(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.OutputFolder = dir
+	cfg.Steps = []config.Step{
+		{Name: "s1", Type: config.ShellStepType, Run: "sleep 5", WorkDir: dir, OutputFilename: filepath.Join(dir, "x.jsonl")},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	err := runner.NewRunner(cfg).Run(ctx)
+
+	assert.Error(t, err)
 }

--- a/step/prompt_step.go
+++ b/step/prompt_step.go
@@ -42,6 +42,19 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 	maxResult := step.ResolvedMaxResults
 	i := 0
 
+	// registerInvalid tracks consecutive invalid LLM responses; it returns a
+	// terminal error once the budget (retryConfig.maxAttempts) is exhausted.
+	invalidAttempts := 0
+	registerInvalid := func(cause error, responseText string) error {
+		invalidAttempts++
+		log.Warn().Err(cause).Msgf("invalid LLM response (attempt %d/%d): %s",
+			invalidAttempts, cfg.RetryConfig.MaxAttempts, responseText)
+		if invalidAttempts >= cfg.RetryConfig.MaxAttempts {
+			return fmt.Errorf("row %d: LLM returned invalid response %d times in a row: %w", i, invalidAttempts, cause)
+		}
+		return nil
+	}
+
 	writer, err := jsonl.NewWriter(step.OutputFilename)
 	if err != nil {
 		return fmt.Errorf("failed to create JSONL writer: %w", err)
@@ -73,11 +86,13 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 
 			for stepName, fieldPaths := range stepGroups {
 				refStep := cfg.GetStepByName(stepName)
+				if refStep == nil {
+					return fmt.Errorf("prompt references unknown step '%s'", stepName)
+				}
 
 				stepValues, err := readStepValuesBatch(*refStep, outputFolder, i, fieldPaths)
 				if err != nil {
-					log.Error().Err(err).Msgf("failed to read values from step '%s'", stepName)
-					break
+					return fmt.Errorf("failed to read values from step '%s': %w", stepName, err)
 				}
 				for fieldPath, stepValue := range stepValues {
 					log.Debug().Msgf("step: %s, field: %s, value: %s", stepName, fieldPath, stepValue.Content)
@@ -89,22 +104,19 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 
 		userPrompt, err := promptBuilder.BuildPrompt()
 		if err != nil {
-			log.Error().Err(err).Msg("failed to build user prompt")
-			break
+			return fmt.Errorf("failed to build prompt: %w", err)
 		}
 
 		var base64Image string
 		if step.HasImages() {
 			imagePath, err := fs.PickImageFile(step.ImagePath, i)
 			if err != nil {
-				log.Error().Err(err).Msgf("failed to find images by pattern: %s, err: %s", step.ImagePath, err)
-				break
+				return fmt.Errorf("failed to find images by pattern '%s': %w", step.ImagePath, err)
 			}
 
 			base64Image, err = fs.ImageToBase64(imagePath)
 			if err != nil {
-				log.Error().Err(err).Msgf("failed to get base64 of image: %s, err: %s", imagePath, err)
-				break
+				return fmt.Errorf("failed to encode image '%s': %w", imagePath, err)
 			}
 
 			promptBuilder.AddValue(base64Image[:15], step.Name, "image", imagePath)
@@ -124,9 +136,10 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 
 		if cfg.ValidateResponse && hasSchemaSchema {
 			log.Debug().Msg("Validating response from LLM using JSON schema")
-			err := step.JSONSchema.ValidateJSONText(response.Text)
-			if err != nil {
-				log.Error().Msgf("JSON response: %s, not following JSON schema. List of errors: %s, retrying", response.Text, err.Error())
+			if err := step.JSONSchema.ValidateJSONText(response.Text); err != nil {
+				if failErr := registerInvalid(err, response.Text); failErr != nil {
+					return failErr
+				}
 				continue
 			}
 		}
@@ -135,16 +148,18 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 
 		lineEntity, err := jsonl.NewLineEntity(response.Text, userPrompt, hasSchemaSchema, promptBuilder.GetValues())
 		if err != nil {
-			log.Err(err).Msgf("got invalid JSON: %+v", response.Text)
+			if failErr := registerInvalid(err, response.Text); failErr != nil {
+				return failErr
+			}
 			continue
 		}
 
 		err = writer.WriteLine(lineEntity)
 		if err != nil {
-			log.Error().Err(err).Msg("failed to write jsonl line to file")
-			break
+			return fmt.Errorf("failed to write output line: %w", err)
 		}
 
+		invalidAttempts = 0
 		i++
 	}
 

--- a/step/prompt_step_test.go
+++ b/step/prompt_step_test.go
@@ -1,0 +1,136 @@
+package step
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/mirpo/datamatic/fs"
+	"github.com/mirpo/datamatic/internal/llmtest"
+	"github.com/mirpo/datamatic/jsonschema"
+	"github.com/mirpo/datamatic/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const titleSchema = `{
+	"type": "object",
+	"properties": {"title": {"type": "string"}},
+	"required": ["title"],
+	"additionalProperties": false
+}`
+
+func testSchema(t *testing.T, raw string) jsonschema.Schema {
+	t.Helper()
+	s, err := jsonschema.LoadSchema(raw)
+	require.NoError(t, err)
+	return *s
+}
+
+func promptStepConfig(t *testing.T, srvURL string) (*config.Config, config.Step, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = dir
+
+	step := config.Step{
+		Name:               "gen",
+		Type:               config.PromptStepType,
+		Prompt:             "generate something",
+		ResolvedMaxResults: 3,
+		OutputFilename:     filepath.Join(dir, "gen.jsonl"),
+		ModelConfig: config.ModelConfig{
+			ModelProvider: llm.ProviderOllama,
+			ModelName:     "test-model",
+			BaseURL:       srvURL,
+		},
+	}
+	return cfg, step, dir
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	lines, err := fs.CountLinesInFile(path)
+	require.NoError(t, err)
+	return lines
+}
+
+func TestPromptStepRun_WritesMaxResultsLines(t *testing.T) {
+	srv := llmtest.NewServer(t, "hello world")
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, countLines(t, step.OutputFilename))
+	assert.Equal(t, 3, srv.CallCount())
+}
+
+func TestPromptStepRun_UnknownRefStepReturnsError(t *testing.T) {
+	srv := llmtest.NewServer(t, "never reached")
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+	step.Prompt = "use {{.ghost.field}}" // no step named "ghost" in cfg.Steps
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+	assert.Equal(t, 0, srv.CallCount())
+}
+
+func TestPromptStepRun_RefValuesReadFailureFailsStep(t *testing.T) {
+	srv := llmtest.NewServer(t, "never reached")
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+
+	// "prev" exists in config but its output file does not exist on disk
+	cfg.Steps = []config.Step{
+		{Name: "prev", Type: config.PromptStepType, OutputFilename: filepath.Join(dir, "missing.jsonl")},
+	}
+	step.Prompt = "use {{.prev}}"
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.Error(t, err, "must fail, not send '<no value>' prompts to the LLM")
+	assert.Contains(t, err.Error(), "prev")
+	assert.Equal(t, 0, srv.CallCount(), "no LLM call with a broken prompt")
+}
+
+func TestPromptStepRun_MissingImagesFailsStep(t *testing.T) {
+	srv := llmtest.NewServer(t, "never reached")
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+	step.ImagePath = filepath.Join(dir, "no-such-dir", "*.jpg")
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.Error(t, err)
+	assert.Equal(t, 0, srv.CallCount())
+}
+
+func TestPromptStepRun_FailsAfterRepeatedInvalidResponses(t *testing.T) {
+	// server always returns JSON that violates the schema (missing "title")
+	srv := llmtest.NewServer(t, `{"wrong": true}`)
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+	step.JSONSchema = testSchema(t, titleSchema)
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.Error(t, err, "must not loop forever on a persistently invalid model")
+	assert.Contains(t, err.Error(), "invalid response")
+	assert.Equal(t, cfg.RetryConfig.MaxAttempts, srv.CallCount(),
+		"one LLM call per allowed attempt, then stop")
+}
+
+func TestPromptStepRun_RecoversAfterTransientInvalidResponse(t *testing.T) {
+	// first response invalid, then valid ones — step must succeed
+	srv := llmtest.NewServer(t, `{"wrong": true}`, `{"title": "ok"}`, `{"title": "ok2"}`, `{"title": "ok3"}`)
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+	step.JSONSchema = testSchema(t, titleSchema)
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, countLines(t, step.OutputFilename))
+	assert.Equal(t, 4, srv.CallCount()) // 1 failed + 3 good
+}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -25,12 +25,23 @@ func setStepType(step *config.Step) error {
 		return errors.New("either 'prompt' or 'run' must be defined")
 	}
 
-	if promptDefined {
-		step.Type = config.PromptStepType
-	} else {
-		step.Type = config.ShellStepType
+	if step.Type != "" && step.Type != config.PromptStepType && step.Type != config.ShellStepType {
+		return fmt.Errorf("unknown step type '%s' (expected 'prompt' or 'shell')", step.Type)
 	}
 
+	inferred := config.ShellStepType
+	sourceField := "run"
+	if promptDefined {
+		inferred = config.PromptStepType
+		sourceField = "prompt"
+	}
+
+	if step.Type != "" && step.Type != inferred {
+		return fmt.Errorf("explicit type '%s' does not match step definition (inferred '%s' from '%s' field)",
+			step.Type, inferred, sourceField)
+	}
+
+	step.Type = inferred
 	return nil
 }
 

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -217,3 +217,31 @@ func TestPreprocessConfig_Failures(t *testing.T) {
 		})
 	}
 }
+
+func TestSetStepType_ExplicitTypeValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		step    config.Step
+		wantErr string // empty = no error
+		want    config.StepType
+	}{
+		{"explicit prompt matches", config.Step{Type: "prompt", Prompt: "p"}, "", config.PromptStepType},
+		{"explicit shell matches", config.Step{Type: "shell", Run: "r"}, "", config.ShellStepType},
+		{"explicit shell but prompt defined", config.Step{Type: "shell", Prompt: "p"}, "does not match", ""},
+		{"explicit prompt but run defined", config.Step{Type: "prompt", Run: "r"}, "does not match", ""},
+		{"unknown explicit type", config.Step{Type: "banana", Run: "r"}, "unknown step type", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := setStepType(&tt.step)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, tt.step.Type)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Batch of verified bug fixes from a code review, implemented TDD-first (red test → fix → green). No config-format changes, no new features.

### Bugs fixed
- **Infinite loop**: schema-validation/JSON-parse failures now count against `retryConfig.maxAttempts` per row; a persistently invalid model fails the step instead of looping (and billing) forever
- **`-http-timeout` was a no-op**: now applied to the HTTP client (`0` = no timeout, as documented)
- **`temperature: 0` silently dropped** by go-openai `omitempty`; now sent (smallest-nonzero-float workaround); valid range widened to 0–2
- **Silent partial success**: prompt steps now fail on ref-value read / prompt build / image / write errors instead of sending `<no value>` prompts to the LLM or truncating output silently
- **Nil-pointer panic** on unknown step references → proper error
- **Response mangling**: surrounding quotes are kept; code fences stripped only when they wrap the response; prompts are only whitespace-trimmed
- **`values` keys**: no more trailing dot for whole-step references (`.step.` → `.step`)
- **`type:` field**: explicit type contradicting `prompt`/`run` now errors; unknown types get a clear message
- Shell output-filename heuristic downgraded to a warning (false positives blocked valid configs)
- New recursive warning for schemas incompatible with OpenAI strict structured output
- Warning on wrap-around line reads (data misalignment visibility)

### Improvements
- SIGINT/SIGTERM → graceful cancellation via `Runner.Run(ctx)`
- Step-error prefix added once in the runner (messages no longer drift per call site)
- Line-count cache removes repeated O(N²) file scans
- Flag defaults sourced from `config.NewConfig()`; CLI warning to stderr

### Tests
- New `internal/llmtest`: mock OpenAI-compatible chat-completions server (test-only, not linked into the binary)
- First-ever coverage for `llm.Generate` and `step.PromptStep.Run` (happy path, timeout, temperature serialization, invalid-response budget, error propagation)

## Test plan
- [x] `go test ./...` — all packages green
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...`