### PR TITLE
fix: pass raw command line to cmd.exe so quotes survive on Windows

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -22,12 +20,7 @@ func ExecuteCommand(ctx context.Context, command string, workingDir string, time
 		defer cancelFunc()
 	}
 
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(cmdCtx, "cmd", "/C", command)
-	} else {
-		cmd = exec.CommandContext(cmdCtx, "sh", "-c", "set -e; "+command)
-	}
+	cmd := newShellCommand(cmdCtx, command)
 
 	cmd.Dir = workingDir
 	cmd.Env = os.Environ()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2,7 +2,10 @@ package executor_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,4 +77,56 @@ func TestExecuteCommand_InvalidWorkingDir(t *testing.T) {
 	err := executor.ExecuteCommand(context.Background(), stepCmd, workingDir, 5*time.Second)
 
 	assert.Error(t, err)
+}
+
+// W1 regression: Go escapes '"' per MSVCRT rules when building the command
+// line, but cmd.exe does not parse backslash escapes — double quotes in run:
+// commands must reach the real shell unmangled. These tests execute the real
+// platform shell (sh -c / cmd /C) and inspect what actually happened.
+func TestExecuteCommand_QuotingReachesShellIntact(t *testing.T) {
+	tests := []struct {
+		name     string
+		unix     string
+		windows  string
+		wantFile string
+		want     string
+	}{
+		{
+			name:     "double-quoted JSON survives to file",
+			unix:     `echo '{"a":1}' > out.json`,
+			windows:  `echo {"a":1}> out.json`,
+			wantFile: "out.json",
+			want:     `{"a":1}`,
+		},
+		{
+			name:     "double quotes wrapping single quotes (duckdb-style SQL)",
+			unix:     `echo "COPY x TO 'out.csv' (FORMAT JSON)" > q.txt`,
+			windows:  `echo "COPY x TO 'out.csv' (FORMAT JSON)"> q.txt`,
+			wantFile: "q.txt",
+			// cmd's echo keeps the surrounding quotes literally; sh strips them —
+			// either way there must be no backslash-escaped quotes inside
+			want: `COPY x TO 'out.csv' (FORMAT JSON)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+
+			stepCmd := tt.unix
+			if runtime.GOOS == "windows" {
+				stepCmd = tt.windows
+			}
+
+			err := executor.ExecuteCommand(context.Background(), stepCmd, workingDir, 30*time.Second)
+			assert.NoError(t, err)
+
+			data, err := os.ReadFile(filepath.Join(workingDir, tt.wantFile))
+			assert.NoError(t, err)
+
+			content := strings.TrimSpace(string(data))
+			assert.NotContains(t, content, `\"`, "double quotes must not arrive backslash-escaped (W1)")
+			assert.Equal(t, tt.want, strings.Trim(content, `"`))
+		})
+	}
 }

--- a/executor/shell_unix.go
+++ b/executor/shell_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package executor
+
+import (
+	"context"
+	"os/exec"
+)
+
+func newShellCommand(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, "sh", "-c", "set -e; "+command)
+}

--- a/executor/shell_windows.go
+++ b/executor/shell_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package executor
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+func newShellCommand(ctx context.Context, command string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "cmd.exe")
+	// Go escapes double quotes per MSVCRT rules when joining Args, but cmd.exe
+	// does not parse backslash escapes — pass the raw command line instead so
+	// quotes in run: commands reach the shell exactly as written (W1).
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "cmd.exe /C " + command}
+	return cmd
+}


### PR DESCRIPTION
## Summary

Real production bug (W1) discovered while debugging PR #60 CI: on Windows, any `run:` command containing double quotes reached the shell mangled.

**Mechanism:** `exec.Command("cmd", "/C", command)` makes Go escape `"` as `\"` per MSVCRT argument rules, but `cmd.exe` parses its command line by its own rules and does not understand backslash escapes. `echo {"a":1} > f` wrote `{\"a\":1}` — invalid JSON. This breaks inline-JSON and duckdb-SQL shell steps (examples 5, 16, 18) for Windows users.

**Fix:** on Windows, bypass Go's escaping via `SysProcAttr{CmdLine: "cmd.exe /C " + command}` so the raw command line reaches `cmd.exe` exactly as written in the YAML. The unix path (`sh -c`) is unchanged; shell construction moved to per-OS files (`shell_unix.go` / `shell_windows.go`).

**Tests:** new `TestExecuteCommand_QuotingReachesShellIntact` executes the **real platform shell** on each CI runner and asserts file contents arrive unescaped:
- double-quoted JSON → file
- double quotes wrapping single quotes (duckdb-style SQL)

These fail on the Windows runner without the fix (exact failure mode observed in PR #60 CI) and pass with it; sh behavior is locked by the same table.

## Test plan
- [x] `go test ./...` green locally (macOS)
- [x] `GOOS=windows go build ./...` cross-compiles
- [x] `golangci-lint run` — 0 issues
- [ ] Windows runner green (the real verification — watch this PR's checks)