### PR TITLE
feat: explicit count/forEach iteration, .item alias, unified config-time validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ollama pull llama3.2
-          # for simplicity, we set maxResults == 1
-          sed -i -e 's/maxResults: 10/maxResults: 1/g' ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml
+          # for simplicity, we set count == 1
+          sed -i -e 's/count: 10/count: 1/g' ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml
           ./datamatic --config ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml --verbose
           cat ./dataset/text_about_country.jsonl | jq

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build multi-step AI workflows with schema-guided reasoning. Works with Ollama, L
 ### Workflow Capabilities
 - **JSON Schema Validation** - Structured output with type safety (YAML-native or JSON string formats)
 - **Text Generation** - Flexible content creation
-- **Multi-step Chaining** - Link generation steps together with template variables
+- **Explicit Iteration** - `count: N` for generators, `forEach: step` to run once per row of an earlier step; reference the current row as `{{.item.field}}`
 - **Schema-Guided Reasoning (SGR)** - Guide LLMs through systematic analysis using structured schemas
 - **Image Analysis** - Visual model integration
 
@@ -72,6 +72,7 @@ version: 1.0
 steps:
   - name: generate_titles
     model: ollama:llama3.2
+    count: 5                    # generate 5 rows
     prompt: Generate a catchy news title
     jsonSchema:
       type: object
@@ -89,9 +90,10 @@ steps:
 
   - name: analyze_title
     model: ollama:llama3.2
+    forEach: generate_titles    # one iteration per generated title
     prompt: |
       Analyze this news title and provide sentiment and category analysis:
-      Title: {{.generate_titles.title}}
+      Title: {{.item.title}}
     jsonSchema: |
       {
         "type": "object",

--- a/config/config.go
+++ b/config/config.go
@@ -1,14 +1,18 @@
 package config
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/mirpo/datamatic/jq"
 	"github.com/mirpo/datamatic/jsonschema"
 	"github.com/mirpo/datamatic/llm"
 	"github.com/mirpo/datamatic/retry"
+	"gopkg.in/yaml.v3"
 )
 
 const (
-	DefaultStepMinMaxResults = 3
+	DefaultStepCount = 3
 )
 
 func NewConfig() *Config {
@@ -48,23 +52,24 @@ const (
 )
 
 type Step struct {
-	Type               StepType    `yaml:"type,omitempty"`
-	Name               string      `yaml:"name"`
-	Model              string      `yaml:"model"`
-	Prompt             string      `yaml:"prompt"`
-	Run                string      `yaml:"run"`
-	JQ                 string      `yaml:"jq"`    // transform steps: jq program
-	From               string      `yaml:"from"`  // transform steps: source step name
-	Limit              int         `yaml:"limit"` // transform steps: cap output rows (0 = no cap)
-	WorkDir            string      `yaml:"workDir,omitempty"`
-	SystemPrompt       string      `yaml:"systemPrompt"`
-	MaxResults         interface{} `yaml:"maxResults"`
-	ModelConfig        ModelConfig `yaml:"modelConfig"`
-	OutputFilename     string      `yaml:"outputFilename"`
-	JSONSchemaRaw      interface{} `yaml:"jsonSchema"`
-	ImagePath          string      `yaml:"imagePath"`
-	ResolvedMaxResults int
-	JSONSchema         jsonschema.Schema
+	Type           StepType    `yaml:"type,omitempty"`
+	Name           string      `yaml:"name"`
+	Model          string      `yaml:"model"`
+	Prompt         string      `yaml:"prompt"`
+	Run            string      `yaml:"run"`
+	JQ             string      `yaml:"jq"`    // transform steps: jq program
+	From           string      `yaml:"from"`  // transform steps: source step name
+	Limit          int         `yaml:"limit"` // transform steps: cap output rows (0 = no cap)
+	WorkDir        string      `yaml:"workDir,omitempty"`
+	SystemPrompt   string      `yaml:"systemPrompt"`
+	Count          int         `yaml:"count"`   // generator steps: how many rows to produce (default 3)
+	ForEach        string      `yaml:"forEach"` // iterate once per row of an earlier step
+	ModelConfig    ModelConfig `yaml:"modelConfig"`
+	OutputFilename string      `yaml:"outputFilename"`
+	JSONSchemaRaw  interface{} `yaml:"jsonSchema"`
+	ImagePath      string      `yaml:"imagePath"`
+	ResolvedCount  int
+	JSONSchema     jsonschema.Schema
 	// JQProgram holds the compiled jq program (set during preprocessing)
 	JQProgram *jq.Program
 }
@@ -75,6 +80,17 @@ type ModelConfig struct {
 	BaseURL       string   `yaml:"baseUrl"`
 	Temperature   *float64 `yaml:"temperature"`
 	MaxTokens     *int     `yaml:"maxTokens"`
+}
+
+// ParseYAML decodes a config strictly: unknown keys (typos, removed syntax
+// like maxResults) are errors instead of being silently ignored.
+func ParseYAML(data []byte, cfg *Config) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(cfg); err != nil {
+		return fmt.Errorf("failed to parse config: %w", err)
+	}
+	return nil
 }
 
 func (c *Config) GetStepByName(name string) *Step {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,3 +41,18 @@ func TestGetStepByName(t *testing.T) {
 		assert.Nil(t, step)
 	})
 }
+
+func TestParseYAML_UnknownFieldsRejected(t *testing.T) {
+	yamlText := `
+version: 1.0
+steps:
+  - name: gen
+    model: ollama:m
+    prompt: hi
+    maxResults: 5
+`
+	var cfg Config
+	err := ParseYAML([]byte(yamlText), &cfg)
+	assert.Error(t, err, "removed/unknown keys must not be silently ignored")
+	assert.Contains(t, err.Error(), "maxResults")
+}

--- a/config/validate.go
+++ b/config/validate.go
@@ -80,30 +80,6 @@ func validateRetryConfig(cfg retry.Config) error {
 	return nil
 }
 
-func validateMaxResults(step *Step, stepNames map[string]bool) error {
-	switch v := step.MaxResults.(type) {
-	case nil, int:
-		return nil
-	case string:
-		if v == "" {
-			// Empty string case is handled in preprocessing
-			return nil
-		}
-
-		if strings.HasSuffix(v, ".$length") {
-			stepName := strings.TrimSuffix(v, ".$length")
-			if !stepNames[stepName] {
-				return fmt.Errorf("maxResults reference to unknown step '%s'", stepName)
-			}
-			return nil
-		}
-
-		return fmt.Errorf("invalid string format for maxResults: '%s'", v)
-	}
-
-	return fmt.Errorf("maxResults unsupported type '%T'", step.MaxResults)
-}
-
 func (c *Config) Validate() error {
 	if err := validateVersion(c.Version); err != nil {
 		return err
@@ -154,6 +130,7 @@ func (c *Config) Validate() error {
 				}
 			}
 
+			// {{.item}} aliases are already resolved during preprocessing
 			promptBuilder := promptbuilder.NewPromptBuilder(step.Prompt)
 			if promptBuilder.HasPlaceholders() {
 				placeholders := promptBuilder.GetPlaceholders()
@@ -187,10 +164,6 @@ func (c *Config) Validate() error {
 
 			if err := validateModelConfig(step.ModelConfig); err != nil {
 				return fmt.Errorf("step '%s': model config validation failed: %w", step.Name, err)
-			}
-
-			if err := validateMaxResults(step, stepNames); err != nil {
-				return fmt.Errorf("step '%s': maxResults validation failed: %w", step.Name, err)
 			}
 		}
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/mirpo/datamatic/promptbuilder"
 	"github.com/mirpo/datamatic/retry"
 	"github.com/rs/zerolog/log"
 )
@@ -85,28 +83,16 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	// If retryConfig is not set in YAML (has zero values), use defaults
-	if c.RetryConfig.MaxAttempts == 0 {
-		c.RetryConfig = retry.NewDefaultConfig()
-	}
-
 	if err := validateRetryConfig(c.RetryConfig); err != nil {
 		return fmt.Errorf("retry config validation failed: %w", err)
 	}
 
-	stepNames := map[string]bool{}
-	cliCalls := []string{}
-
 	for index := range c.Steps {
 		step := &c.Steps[index]
-
-		stepNames[step.Name] = true
 
 		stepType := step.Type
 
 		if stepType == ShellStepType {
-			cliCalls = append(cliCalls, fmt.Sprintf("- %s", step.Run))
-
 			filename := filepath.Base(step.OutputFilename)
 			if !strings.Contains(step.Run, filename) {
 				log.Warn().Msgf("step '%s': output filename '%s' not found in run command — make sure the command actually creates this file",
@@ -124,54 +110,23 @@ func (c *Config) Validate() error {
 				}
 			}
 
-			if strings.Contains(step.Prompt, "{{.SYSTEM.JSON_SCHEMA}}") {
-				if err := step.JSONSchema.EnsureAllPropertiesRequired(); err != nil {
-					return fmt.Errorf("step '%s': JSON schema validation failed when using '{{.SYSTEM.JSON_SCHEMA}}' in prompt: %w", step.Name, err)
-				}
-			}
-
-			// {{.item}} aliases are already resolved during preprocessing
-			promptBuilder := promptbuilder.NewPromptBuilder(step.Prompt)
-			if promptBuilder.HasPlaceholders() {
-				placeholders := promptBuilder.GetPlaceholders()
-				for _, val := range placeholders {
-					if !stepNames[val.Step] {
-						return fmt.Errorf("placeholder has a references to unknown or not previous steps, step: %s, placeholder: %+v", step.Name, val)
-					}
-
-					// JSON key - supports nested paths like "user.profile.name"
-					if len(val.Key) > 0 {
-						refStep := c.GetStepByName(val.Step)
-						if refStep.Type == PromptStepType {
-							if !refStep.JSONSchema.HasSchemaDefinition() {
-								return fmt.Errorf("step %s must have JSON schema, key: %s", val.Step, val.Key)
-							}
-
-							if strings.Contains(val.Key, ".") {
-								if !refStep.JSONSchema.HasFieldPath(val.Key) {
-									return fmt.Errorf("field path '%s' not found in step %s JSON schema", val.Key, val.Step)
-								}
-							} else {
-								// For single field, use existing validation
-								if !refStep.JSONSchema.HasRequiredProperty(val.Key) {
-									return fmt.Errorf("'%s' key must be defined in step %s in JSON schema as a property and required", val.Key, val.Step)
-								}
-							}
-						}
-					}
-				}
-			}
-
 			if err := validateModelConfig(step.ModelConfig); err != nil {
 				return fmt.Errorf("step '%s': model config validation failed: %w", step.Name, err)
 			}
 		}
 	}
 
-	if !c.SkipCliWarning && len(cliCalls) > 0 {
-		fmt.Fprintf(os.Stderr, "⚠️ WARNING: External application call detected! The author assumes no responsibility for execution results. Please verify all external calls before proceeding. Use at your own risk.\n\nCalls: \n%s\n\nPress Enter to continue", strings.Join(cliCalls, "\n"))
-		fmt.Scanln() //nolint:golint,errcheck
-	}
-
 	return nil
+}
+
+// ShellCommands returns the run commands of all shell steps, used by the CLI
+// to warn the user before executing external applications.
+func (c *Config) ShellCommands() []string {
+	var commands []string
+	for _, step := range c.Steps {
+		if step.Type == ShellStepType {
+			commands = append(commands, step.Run)
+		}
+	}
+	return commands
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -100,21 +100,21 @@ func TestValidateConfig(t *testing.T) {
 						MaxTokens:   &maxTokens500,
 						BaseURL:     "http://localhost:11434",
 					},
-					MaxResults: 10,
+					Count: 10,
 				},
 				{
-					Name:       "step2_cli",
-					Type:       PromptStepType,
-					Model:      "ollama:dummy",
-					Prompt:     "Generate new.",
-					MaxResults: DefaultStepMinMaxResults,
+					Name:   "step2_cli",
+					Type:   PromptStepType,
+					Model:  "ollama:dummy",
+					Prompt: "Generate new.",
+					Count:  DefaultStepCount,
 				},
 				{
-					Name:       "step3_default_maxresults",
-					Type:       PromptStepType,
-					Model:      "lmstudio:dummy",
-					Prompt:     "Another prompt.",
-					MaxResults: 1,
+					Name:   "step3_count_one",
+					Type:   PromptStepType,
+					Model:  "lmstudio:dummy",
+					Prompt: "Another prompt.",
+					Count:  1,
 				},
 			},
 		}
@@ -126,13 +126,13 @@ func TestValidateConfig(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, PromptStepType, cfg.Steps[0].Type)
-		assert.Equal(t, 10, cfg.Steps[0].MaxResults)
+		assert.Equal(t, 10, cfg.Steps[0].Count)
 
 		assert.Equal(t, PromptStepType, cfg.Steps[1].Type)
-		assert.Equal(t, DefaultStepMinMaxResults, cfg.Steps[1].MaxResults)
+		assert.Equal(t, DefaultStepCount, cfg.Steps[1].Count)
 
 		assert.Equal(t, PromptStepType, cfg.Steps[2].Type)
-		assert.Equal(t, 1, cfg.Steps[2].MaxResults)
+		assert.Equal(t, 1, cfg.Steps[2].Count)
 	})
 
 	t.Run("Step With Invalid Model Config", func(t *testing.T) {
@@ -143,48 +143,6 @@ func TestValidateConfig(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "step 'step1': model config validation failed: temperature must be between 0 and 2")
 	})
-
-	t.Run("MaxResults Defaults Correctly", func(t *testing.T) {
-		cfg := validConfig()
-
-		err := cfg.Validate()
-		assert.NoError(t, err)
-
-		assert.Equal(t, 10, cfg.Steps[0].MaxResults, "step with MaxResults > 0 should keep its value")
-		assert.Equal(t, DefaultStepMinMaxResults, cfg.Steps[1].MaxResults, "step with MaxResults = nil should default")
-		assert.Equal(t, 1, cfg.Steps[2].MaxResults, "step with MaxResults < 0 should default")
-	})
-}
-
-func TestValidateMaxResults(t *testing.T) {
-	stepNames := map[string]bool{"foo": true, "bar": true}
-
-	tests := []struct {
-		name        string
-		input       interface{}
-		expectError bool
-	}{
-		{"nil input", nil, false},
-		{"empty string", "", false},
-		{"valid step reference", "foo.$length", false},
-		{"invalid step reference", "unknown.$length", true},
-		{"invalid string", "invalid", true},
-		{"zero int", 0, false},
-		{"positive int", 5, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			step := &Step{MaxResults: tt.input}
-			err := validateMaxResults(step, stepNames)
-
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestCLIFilenameValidation_PostPreprocessing(t *testing.T) {

--- a/datamatic.go
+++ b/datamatic.go
@@ -70,7 +70,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Expanding environment variables in config file")
 	}
 
-	err = yaml.Unmarshal([]byte(expandedYaml), &cfg)
+	err = config.ParseYAML([]byte(expandedYaml), cfg)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Parsing config file")
 	}

--- a/datamatic.go
+++ b/datamatic.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/goforj/godump"
@@ -83,6 +85,11 @@ func main() {
 	err = cfg.Validate()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to validate config file")
+	}
+
+	if commands := cfg.ShellCommands(); !cfg.SkipCliWarning && len(commands) > 0 {
+		fmt.Fprintf(os.Stderr, "⚠️ WARNING: External application call detected! The author assumes no responsibility for execution results. Please verify all external calls before proceeding. Use at your own risk.\n\nCalls: \n- %s\n\nPress Enter to continue", strings.Join(commands, "\n- "))
+		fmt.Scanln() //nolint:golint,errcheck
 	}
 
 	if cfg.Verbose {

--- a/examples/v1/1. simple text generation, not linked steps/config.yaml
+++ b/examples/v1/1. simple text generation, not linked steps/config.yaml
@@ -12,7 +12,7 @@ steps:
       You are a creative news title generator. Avoid repeating topics about aliens, UFOs, outer space, or extraterrestrial life. Explore topics like technology,  nature, sports, politics, or bizarre everyday events.
     prompt: |
       Generate a catchy and one unique news title. Come up with a wildly different and surprising news headline. Return only one news title per request, without any extra thinking.
-    maxResults: 15
+    count: 15
     modelConfig:
       baseUrl: http://localhost:1234/v1
       temperature: 0.7

--- a/examples/v1/10. openrouter-example/config.yaml
+++ b/examples/v1/10. openrouter-example/config.yaml
@@ -8,7 +8,7 @@ steps:
     prompt: |
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
-    maxResults: 5
+    count: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -23,7 +23,7 @@ steps:
       - Age (between 25-65)
       - Occupation
       - Brief backstory (2-3 sentences)
-    maxResults: 3
+    count: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/examples/v1/11. gemini-example/config.yaml
+++ b/examples/v1/11. gemini-example/config.yaml
@@ -8,7 +8,7 @@ steps:
     prompt: |
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
-    maxResults: 5
+    count: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -23,7 +23,7 @@ steps:
       - Age (between 25-65)
       - Occupation
       - Brief backstory (2-3 sentences)
-    maxResults: 3
+    count: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/examples/v1/12. cv-processing-pipeline/config.yaml
+++ b/examples/v1/12. cv-processing-pipeline/config.yaml
@@ -21,14 +21,14 @@ steps:
       - Measurable achievements and impact
 
       Format as a professional CV text document.
-    maxResults: 3
+    count: 3
     modelConfig:
       temperature: 0.8
       maxTokens: 3000
 
   - name: extract_companies
     model: ollama:llama3.2
-    maxResults: generate_cv.$length
+    forEach: generate_cv
     prompt: |
       Extract all employment information from this CV. Focus on companies, roles, and dates.
 
@@ -93,7 +93,7 @@ steps:
 
   - name: extract_courses
     model: ollama:llama3.2
-    maxResults: generate_cv.$length
+    forEach: generate_cv
     prompt: |
       Extract all education and certification information from this CV.
 

--- a/examples/v1/13. retry configuration example/config.yaml
+++ b/examples/v1/13. retry configuration example/config.yaml
@@ -12,4 +12,4 @@ steps:
     prompt: |
       Generate a creative short story title about time travel.
       Make it intriguing and unique. Return only the title.
-    maxResults: 3
+    count: 3

--- a/examples/v1/14. recipe generation with nested fields/config.yaml
+++ b/examples/v1/14. recipe generation with nested fields/config.yaml
@@ -8,7 +8,7 @@ steps:
     prompt: |
       Generate a complete recipe with detailed ingredients, nutrition information, and cooking details.
       Create a diverse and interesting recipe from any cuisine. Include specific ingredient quantities
-      and nutritional values. Return the data in the structured JSON format below.
+      and nutritional values. Return as JSON.
     jsonSchema:
       type: object
       properties:

--- a/examples/v1/14. recipe generation with nested fields/config.yaml
+++ b/examples/v1/14. recipe generation with nested fields/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 steps:
   - name: recipe_data
     model: ollama:llama3.2
-    maxResults: 5
+    count: 5
     modelConfig:
       temperature: 0.8
     prompt: |
@@ -110,7 +110,7 @@ steps:
 
   - name: cooking_guide
     model: ollama:llama3.2
-    maxResults: recipe_data.$length
+    forEach: recipe_data
     modelConfig:
       temperature: 0.7
       maxTokens: 1500

--- a/examples/v1/15. simple math reasoning/config.yaml
+++ b/examples/v1/15. simple math reasoning/config.yaml
@@ -16,7 +16,7 @@ steps:
   - name: solve_with_reasoning
     type: prompt
     model: ollama:llama3.2
-    maxResults: math_problems_10.$length
+    forEach: math_problems_10
     modelConfig:
       temperature: 0.7
     prompt: |

--- a/examples/v1/16. sql reasoning with checklist/config.yaml
+++ b/examples/v1/16. sql reasoning with checklist/config.yaml
@@ -16,7 +16,7 @@ steps:
   - name: generate_sql_with_reasoning
     type: prompt
     model: ollama:llama3.2
-    maxResults: convert_to_jsonl.$length
+    forEach: convert_to_jsonl
     modelConfig:
       temperature: 0.3
     systemPrompt: |

--- a/examples/v1/17. document classification with schema-guided reasoning/config.yaml
+++ b/examples/v1/17. document classification with schema-guided reasoning/config.yaml
@@ -55,7 +55,7 @@ steps:
       Document:
       {{.generate_documents.text}}
 
-      Analyze the document and provide a complete classification following the schema below.
+      Analyze the document and provide a complete classification as JSON.
     jsonSchema:
       type: object
       properties:

--- a/examples/v1/17. document classification with schema-guided reasoning/config.yaml
+++ b/examples/v1/17. document classification with schema-guided reasoning/config.yaml
@@ -4,7 +4,7 @@ steps:
   - name: generate_documents
     type: prompt
     model: ollama:llama3.2
-    maxResults: 10
+    count: 10
     modelConfig:
       temperature: 0.9
     systemPrompt: |
@@ -35,7 +35,7 @@ steps:
   - name: classify_documents
     type: prompt
     model: ollama:llama3.2
-    maxResults: generate_documents.$length
+    forEach: generate_documents
     modelConfig:
       temperature: 0.3
       maxTokens: 2000

--- a/examples/v1/18. workdir-multi-stage-pipeline/config.yaml
+++ b/examples/v1/18. workdir-multi-stage-pipeline/config.yaml
@@ -27,7 +27,7 @@ steps:
 
   - name: analyze_complexity
     model: $PROVIDER:$MODEL
-    maxResults: convert_to_jsonl.$length
+    forEach: convert_to_jsonl
     systemPrompt: |
       You are an expert in analyzing instructional prompts and assessing their complexity.
       Rate prompts based on:

--- a/examples/v1/19. transform step and fan-out/README.md
+++ b/examples/v1/19. transform step and fan-out/README.md
@@ -4,7 +4,7 @@ Shows the built-in `jq` transform step turning **one structured LLM answer into 
 
 1. `team_roster` — LLM generates 3 team rosters, each with an array of members (JSON schema enforced)
 2. `members` — transform step explodes `members[]`: 3 roster rows become N member rows, no external tools
-3. `bio` — one LLM call per member (`maxResults: members.$length`), referencing `{{.members.name}}` and `{{.members.role}}`
+3. `bio` — one LLM call per member (`forEach: members`), referencing the current row as `{{.item.name}}` and `{{.item.role}}`
 
 This 1-row → N-rows pattern was impossible without shell + external `jq` before; now it's one YAML step and jq programs are validated at config load.
 

--- a/examples/v1/19. transform step and fan-out/config.yaml
+++ b/examples/v1/19. transform step and fan-out/config.yaml
@@ -3,7 +3,7 @@ version: 1.0
 steps:
   - name: team_roster
     model: ollama:llama3.2
-    maxResults: 3
+    count: 3
     modelConfig:
       temperature: 0.9
     prompt: |
@@ -35,6 +35,6 @@ steps:
 
   - name: bio
     model: ollama:llama3.2
-    maxResults: members.$length
+    forEach: members
     prompt: |
-      Write a two-sentence bio for {{.members.name}}, who works as {{.members.role}}.
+      Write a two-sentence bio for {{.item.name}}, who works as {{.item.role}}.

--- a/examples/v1/2. simple json generation, not linked steps/config.yaml
+++ b/examples/v1/2. simple json generation, not linked steps/config.yaml
@@ -24,7 +24,7 @@ steps:
       You are a creative news title generator. Avoid repeating topics about aliens, UFOs, outer space, or extraterrestrial life. Explore topics like technology,  nature, sports, politics, or bizarre everyday events.
     prompt: |
       Generate a catchy and one unique news title. Come up with a wildly different and surprising news headline. Return only one news title per request, without any extra thinking.
-    maxResults: 15
+    count: 15
     jsonSchema:
       type: object
       properties:

--- a/examples/v1/3. complex json, linked steps/config.yaml
+++ b/examples/v1/3. complex json, linked steps/config.yaml
@@ -6,7 +6,7 @@ steps:
     modelConfig:
       temperature: 0.9
     prompt: |
-      Provide up-to-date information about a randomly selected country, including its name, population, land area, UN membership status, capital city, GDP per capita, official languages, and year of independence. Return the data in a structured JSON format according to the schema below.
+      Provide up-to-date information about a randomly selected country, including its name, population, land area, UN membership status, capital city, GDP per capita, official languages, and year of independence. Return as JSON.
     jsonSchema:
       type: object
       properties:

--- a/examples/v1/3. complex json, linked steps/config.yaml
+++ b/examples/v1/3. complex json, linked steps/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 steps:
   - name: about_country
     model: ollama:llama3.2
-    maxResults: 10
+    count: 10
     modelConfig:
       temperature: 0.9
     prompt: |
@@ -52,7 +52,7 @@ steps:
 
   - name: text_about_country
     model: ollama:llama3.2
-    maxResults: about_country.$length # use the result length of the referenced step
+    forEach: about_country
     modelConfig:
       temperature: 0.9
       maxTokens: 5000

--- a/examples/v1/4. using huggingface and jq cli/config.yaml
+++ b/examples/v1/4. using huggingface and jq cli/config.yaml
@@ -48,7 +48,7 @@ steps:
       - Cover expected behavior, edge cases, and invalid input scenarios
       - Use `pytest` syntax and idioms for Python tests
       - Avoid wrapping your output in triple backticks (e.g., ```python)
-      - Output tests as a structured JSON array with each test's name, description, and code
+      - Output a single runnable test file, nothing else
       - Focus on clarity, correctness, and high code coverage
     prompt: |
       Generate a complete, production-ready unit test file for the following code. Your output should:

--- a/examples/v1/4. using huggingface and jq cli/config.yaml
+++ b/examples/v1/4. using huggingface and jq cli/config.yaml
@@ -13,7 +13,7 @@ steps:
   - name: explain_code
     type: prompt
     model: ollama:llama3.2
-    maxResults: pick_first_20.$length # use the result length of the referenced step
+    forEach: pick_first_20
     systemPrompt: |
       You are an expert software engineer and code analyst with deep understanding of algorithms, data structures, and software design patterns. Your task is to analyze code and explain its logic in clear, precise terms. Focus on:
       - Breaking down complex logic into understandable steps
@@ -41,7 +41,7 @@ steps:
   - name: unit_test
     type: prompt
     model: ollama:llama3.2
-    maxResults: explain_code.$length # use the result length of the referenced step
+    forEach: explain_code
     systemPrompt: |
       You are an expert software engineer and test automation specialist. Your task is to generate comprehensive, accurate unit tests based on provided code descriptions and code snippets. Follow these instructions:
 

--- a/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/config.yaml
+++ b/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/config.yaml
@@ -19,7 +19,7 @@ steps:
   - name: explain_math
     type: prompt
     model: lmstudio:hermes-3-llama-3.2-3b
-    maxResults: synthetic_math.$length # use the result length of the referenced step
+    forEach: synthetic_math
     systemPrompt: |
       You are a specialized mathematics analysis assistant designed to break down and explain mathematical problems and solutions. Your primary functions include:
 

--- a/examples/v1/6. git dataset/config.yaml
+++ b/examples/v1/6. git dataset/config.yaml
@@ -19,11 +19,11 @@ steps:
       required:
         - subtopics
 
+  # built-in transform: dedupe within the single roster row and fan out to
+  # one row per subtopic (jq sees the response value, not the file format)
   - name: split_into_unique_subtopics
-    type: shell
-    run: |
-      cat ./generate_subtopics.jsonl | jq -c '.response.subtopics[]' | sort | uniq | jq -c '{id: . | @base64, topic: .}' > ./split_into_unique_subtopics.jsonl
-    outputFilename: split_into_unique_subtopics.jsonl
+    from: generate_subtopics
+    jq: '.subtopics | unique | .[] | {id: (. | @base64), topic: .}'
 
   - name: generate_instructions
     model: ollama:llama3.2
@@ -49,6 +49,8 @@ steps:
       required:
         - instructions
 
+  # stays a shell step: dedupe ACROSS rows needs the whole file at once,
+  # which per-row transform steps can't do yet (fan-in)
   - name: split_into_unique_instructions
     type: shell
     run: |

--- a/examples/v1/6. git dataset/config.yaml
+++ b/examples/v1/6. git dataset/config.yaml
@@ -6,7 +6,7 @@ steps:
     prompt: |
       I am building a dataset of Git-related questions and commands. List exactly 30 distinct subtopics that comprehensively cover core and advanced Git usage. Do not number the subtopics. Separate them only with commas, with no additional text or formatting.
       Each subtopic should be a short phrase, and they should be relevant to Git commands, concepts, or workflows. The subtopics should be diverse and cover various aspects of Git, including but not limited to version control, branching, merging, rebasing, conflict resolution, and collaboration.
-    maxResults: 1
+    count: 1
     jsonSchema:
       type: object
       properties:
@@ -38,7 +38,7 @@ steps:
     modelConfig:
       temperature: 0.9
       maxTokens: 5000
-    maxResults: split_into_unique_subtopics.$length # for each unique subtopic generate N instructions
+    forEach: split_into_unique_subtopics
     jsonSchema:
       type: object
       properties:
@@ -66,7 +66,7 @@ steps:
       - Avoid unnecessary tangents or deep Git internals unless the instruction explicitly requires it.
 
       Instruction: "{{.split_into_unique_instructions.instruction}}"
-    maxResults: split_into_unique_instructions.$length
+    forEach: split_into_unique_instructions
 
   - name: instruction_response
     type: shell
@@ -131,7 +131,7 @@ steps:
     modelConfig:
       temperature: 0.9
       maxTokens: 5000
-    maxResults: instruction_response.$length # for each instruction-response pair generate an evaluation
+    forEach: instruction_response
     jsonSchema:
       type: object
       properties:

--- a/examples/v1/7. fine-tuning dataset/config.yaml
+++ b/examples/v1/7. fine-tuning dataset/config.yaml
@@ -13,7 +13,7 @@ steps:
 
   - name: questions_per_chunk
     model: ollama:deepseek-r1:1.5b
-    maxResults: chopdoc_by_sentence.$length # for each chunk generate 3 questions
+    forEach: chopdoc_by_sentence
     prompt: |
       For the following text chunk, generate exactly **3 questions**, each based on a different level of cognitive thinking. For each question, you must also provide direct text evidence from the chunk that supports or relates to the question.
 
@@ -71,7 +71,7 @@ steps:
 
   - name: validate_questions
     model: ollama:deepseek-r1:1.5b
-    maxResults: flatten_question_chunk.$length # for each question chunk validate
+    forEach: flatten_question_chunk
     prompt: |
       prompt: |
       Evaluate the provided question based *solely* on its alignment with the accompanying text chunk and the effectiveness of the supplied text evidence. Your assessment should be rigorous, ensuring accuracy and relevance to the given content.

--- a/examples/v1/7. fine-tuning dataset/config.yaml
+++ b/examples/v1/7. fine-tuning dataset/config.yaml
@@ -73,7 +73,6 @@ steps:
     model: ollama:deepseek-r1:1.5b
     forEach: flatten_question_chunk
     prompt: |
-      prompt: |
       Evaluate the provided question based *solely* on its alignment with the accompanying text chunk and the effectiveness of the supplied text evidence. Your assessment should be rigorous, ensuring accuracy and relevance to the given content.
 
       ---

--- a/examples/v1/8. hugginface images and qwen2.5vl or gemma3/config.yaml
+++ b/examples/v1/8. hugginface images and qwen2.5vl or gemma3/config.yaml
@@ -18,7 +18,6 @@ steps:
     type: prompt
     model: ollama:qwen2.5vl:3b
     # model: lmstudio:gemma-3-4b-it
-    maxResults: download_dataset.$length # number of images
     prompt: |
       Image contains mathematical formula. Convert to Latex. Don't add any extra information
     imagePath: |
@@ -28,7 +27,7 @@ steps:
     type: prompt
     model: ollama:qwen2.5vl:3b
     # model: lmstudio:gemma-3-4b-it
-    maxResults: analyze_math_image.$length # use the result length of the referenced step
+    forEach: analyze_math_image
     prompt: |
       Given the following formula, break down the steps needed to understand or solve it. Start by identifying the type of mathematical expression it is (e.g., complex numbers, exponential form, etc.), then explain each term and operation, and proceed to derive or simplify as appropriate. Show your reasoning at each step. Format your response in clear Markdown, using headings, bullet points, and LaTeX for math where helpful.
       Formula: {{.analyze_math_image}}

--- a/examples/v1/9. openai-example/config.yaml
+++ b/examples/v1/9. openai-example/config.yaml
@@ -8,7 +8,7 @@ steps:
     prompt: |
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
-    maxResults: 5
+    count: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -23,7 +23,7 @@ steps:
       - Age (between 25-65)
       - Occupation
       - Brief backstory (2-3 sentences)
-    maxResults: 3
+    count: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/fs/reader.go
+++ b/fs/reader.go
@@ -26,7 +26,7 @@ func NewLineScanner(r io.Reader) *bufio.Scanner {
 var lineCountCache sync.Map // path -> int
 
 func ReadLineFromFile(path string, lineNumber int) (string, error) {
-	lineCount, err := cachedLineCount(path)
+	lineCount, err := CachedLineCount(path)
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,9 @@ func ReadLineFromFile(path string, lineNumber int) (string, error) {
 	return "", errors.New("unexpected error: target line not found")
 }
 
-func cachedLineCount(path string) (int, error) {
+// CachedLineCount returns the line count of a step-output file, caching it for
+// the lifetime of the run (step outputs are immutable once their step completes).
+func CachedLineCount(path string) (int, error) {
 	if v, ok := lineCountCache.Load(path); ok {
 		return v.(int), nil
 	}

--- a/promptbuilder/promptbuilder.go
+++ b/promptbuilder/promptbuilder.go
@@ -2,6 +2,7 @@ package promptbuilder
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -56,6 +57,24 @@ func parseTemplatePlaceholders(input string) map[string]PlaceholderInfo {
 	}
 
 	return placeholders
+}
+
+// ItemAliasName is the reserved placeholder name for the forEach source row;
+// step names must not shadow it (enforced during preprocessing).
+const ItemAliasName = "item"
+
+var itemAliasRe = regexp.MustCompile(`{{\s*\.item(\.[^\s}]+)?\s*}}`)
+
+// ResolveItemAlias rewrites {{.item...}} placeholders to the forEach source
+// step, so downstream parsing/validation sees a regular step reference.
+func ResolveItemAlias(prompt string, forEachSource string) (string, error) {
+	if !itemAliasRe.MatchString(prompt) {
+		return prompt, nil
+	}
+	if forEachSource == "" {
+		return "", errors.New("prompt uses {{.item}} but the step has no forEach")
+	}
+	return itemAliasRe.ReplaceAllString(prompt, "{{."+forEachSource+"$1}}"), nil
 }
 
 func NewPromptBuilder(prompt string) *PromptBuilder {

--- a/promptbuilder/promptbuilder.go
+++ b/promptbuilder/promptbuilder.go
@@ -180,10 +180,6 @@ func (pb *PromptBuilder) GetValues() map[string]ValueShort {
 	resultValues := map[string]ValueShort{}
 
 	for stepName, stepFields := range pb.stepData {
-		if strings.HasPrefix(stepName, "SYSTEM") {
-			continue
-		}
-
 		for fieldPath, stepValue := range stepFields {
 			key := "." + stepName
 			if fieldPath != "" {

--- a/promptbuilder/promptbuilder_test.go
+++ b/promptbuilder/promptbuilder_test.go
@@ -230,7 +230,6 @@ func TestPromptBuilder_GetValues(t *testing.T) {
 	builder := NewPromptBuilder("Test prompt.")
 	builder.AddValue("1", "USER", "name", "John Doe")
 	builder.AddValue("2", "USER", "email", "john.doe@example.com")
-	builder.AddValue("3", "SYSTEM", "version", "v1.0")
 	builder.AddValue("4", "INPUT", "query", "search term")
 
 	expected := map[string]ValueShort{

--- a/promptbuilder/promptbuilder_test.go
+++ b/promptbuilder/promptbuilder_test.go
@@ -253,3 +253,33 @@ func TestPromptBuilder_GetValues_WholeStepReference(t *testing.T) {
 		".generate_cv": {ID: "1", Value: "full cv text"},
 	}, actual, "no trailing dot for whole-step references")
 }
+
+func TestResolveItemAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		prompt  string
+		source  string
+		want    string
+		wantErr string
+	}{
+		{"no item placeholders", "plain {{.other.x}}", "src", "plain {{.other.x}}", ""},
+		{"whole item", "use {{.item}}", "src", "use {{.src}}", ""},
+		{"item field", "use {{.item.title}}", "src", "use {{.src.title}}", ""},
+		{"item nested field", "use {{.item.a.b}}", "src", "use {{.src.a.b}}", ""},
+		{"multiple mixed", "{{.item.a}} and {{.src.b}} and {{.item}}", "src", "{{.src.a}} and {{.src.b}} and {{.src}}", ""},
+		{"spaces inside braces", "use {{ .item.title }}", "src", "use {{.src.title}}", ""},
+		{"item without forEach", "use {{.item.x}}", "", "", "no forEach"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveItemAlias(tt.prompt, tt.source)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
@@ -32,44 +31,42 @@ func (r *Runner) PrepareOutputDirectory() error {
 	return nil
 }
 
-func (r *Runner) resolveMaxResults(step *config.Step) error {
-	switch v := step.MaxResults.(type) {
-	case int:
-		step.ResolvedMaxResults = v
-		return nil
-
-	case string:
-		if strings.HasSuffix(v, ".$length") {
-			refStepName := strings.TrimSuffix(v, ".$length")
-			refStep := r.cfg.GetStepByName(refStepName)
-
-			if refStep == nil {
-				return fmt.Errorf("reference step '%s' not found", refStepName)
-			}
-
-			isImageStep := step.HasImages()
-			if isImageStep {
-				imagesCount, err := fs.CountFiles(step.ImagePath)
-				if err != nil {
-					return fmt.Errorf("failed to count images in folder '%s': %w", step.ImagePath, err)
-				}
-				step.ResolvedMaxResults = imagesCount
-				log.Debug().Msgf("Resolved MaxResults for step '%s' to %d from refStep: %s", step.Name, imagesCount, refStepName)
-			} else {
-				lines, err := fs.CountLinesInFile(refStep.OutputFilename)
-				if err != nil {
-					return fmt.Errorf("failed to count lines in '%s': %w", refStep.OutputFilename, err)
-				}
-
-				step.ResolvedMaxResults = lines
-				log.Debug().Msgf("Resolved MaxResults for step '%s' to %d from refStep: %s", step.Name, lines, refStepName)
-			}
-
-			return nil
+// resolveIterations sets how many rows a prompt step produces: forEach source
+// row count, image-glob match count, explicit count, or the generator default.
+// This is the single place the iteration-source decision lives.
+func (r *Runner) resolveIterations(step *config.Step) error {
+	switch {
+	case step.ForEach != "":
+		refStep := r.cfg.GetStepByName(step.ForEach)
+		if refStep == nil {
+			return fmt.Errorf("forEach references unknown step '%s'", step.ForEach)
 		}
+
+		lines, err := fs.CachedLineCount(refStep.OutputFilename)
+		if err != nil {
+			return fmt.Errorf("failed to count rows of step '%s': %w", step.ForEach, err)
+		}
+
+		step.ResolvedCount = lines
+		log.Debug().Msgf("Resolved iterations for step '%s' to %d from forEach: %s", step.Name, lines, step.ForEach)
+
+	case step.HasImages() && step.Count == 0:
+		images, err := fs.CountFiles(step.ImagePath)
+		if err != nil {
+			return fmt.Errorf("failed to count images matching '%s': %w", step.ImagePath, err)
+		}
+
+		step.ResolvedCount = images
+		log.Debug().Msgf("Resolved iterations for step '%s' to %d from imagePath: %s", step.Name, images, step.ImagePath)
+
+	case step.Count == 0:
+		step.ResolvedCount = config.DefaultStepCount
+
+	default:
+		step.ResolvedCount = step.Count
 	}
 
-	return fmt.Errorf("unexpected MaxResults value: %v", step.MaxResults)
+	return nil
 }
 
 func (r *Runner) Run(ctx context.Context) error {
@@ -85,8 +82,8 @@ func (r *Runner) Run(ctx context.Context) error {
 		log.Info().Msgf("Starting step: '%s' (type: '%s')", stepConfig.Name, stepConfig.Type)
 
 		if stepConfig.Type == config.PromptStepType {
-			if err := r.resolveMaxResults(&stepConfig); err != nil {
-				return fmt.Errorf("failed to resolve MaxResults for step '%s', err: %w", stepConfig.Name, err)
+			if err := r.resolveIterations(&stepConfig); err != nil {
+				return fmt.Errorf("failed to resolve iterations for step '%s': %w", stepConfig.Name, err)
 			}
 		}
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -122,7 +122,7 @@ func TestRun_TransformPipelineEndToEnd(t *testing.T) {
 			Name:    "describe",
 			Model:   "ollama:test-model",
 			ForEach: "picked",
-			Prompt:  "Describe {{.item}}", // .item alias resolved during preprocessing
+			Prompt:  "Describe {{.item}}",
 			ModelConfig: config.ModelConfig{
 				BaseURL: srv.URL,
 			},

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mirpo/datamatic/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func TestValidateConfigFromExamples(t *testing.T) {
@@ -37,8 +36,8 @@ func TestValidateConfigFromExamples(t *testing.T) {
 			assert.NoError(t, err, "Failed to expand env vars for file: %s", path)
 
 			var cfg config.Config
-			err = yaml.Unmarshal([]byte(expandedYaml), &cfg)
-			assert.NoError(t, err, "Failed to unmarshal YAML: %s", path)
+			err = config.ParseYAML([]byte(expandedYaml), &cfg)
+			assert.NoError(t, err, "Failed to parse YAML: %s", path)
 
 			cfg.OutputFolder = "test"
 			cfg.SkipCliWarning = true
@@ -101,10 +100,9 @@ func TestRun_TransformPipelineEndToEnd(t *testing.T) {
 	cfg.Version = "1.0"
 	cfg.Steps = []config.Step{
 		{
-			Name:       "seed",
-			Model:      "ollama:test-model",
-			MaxResults: 3,
-			Prompt:     "Suggest a topic",
+			Name:   "seed", // no count: generator default (3) resolved at runtime
+			Model:  "ollama:test-model",
+			Prompt: "Suggest a topic",
 			JSONSchemaRaw: `{
 				"type": "object",
 				"properties": {"topic": {"type": "string"}, "keep": {"type": "boolean"}},
@@ -121,10 +119,10 @@ func TestRun_TransformPipelineEndToEnd(t *testing.T) {
 			From: "seed",
 		},
 		{
-			Name:       "describe",
-			Model:      "ollama:test-model",
-			MaxResults: "picked.$length",
-			Prompt:     "Describe {{.picked}}",
+			Name:    "describe",
+			Model:   "ollama:test-model",
+			ForEach: "picked",
+			Prompt:  "Describe {{.item}}", // .item alias resolved during preprocessing
 			ModelConfig: config.ModelConfig{
 				BaseURL: srv.URL,
 			},

--- a/step/prompt_step.go
+++ b/step/prompt_step.go
@@ -66,6 +66,8 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 		return fmt.Errorf("failed to create LLM provider: %w", err)
 	}
 
+	hasSchemaSchema := step.JSONSchema.HasSchemaDefinition()
+
 	for i < maxResult {
 		log.Info().
 			Str("step_name", step.Name).
@@ -74,12 +76,6 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 			Msg("Running step")
 
 		promptBuilder := promptbuilder.NewPromptBuilder(step.Prompt)
-		hasSchemaSchema := step.JSONSchema.HasSchemaDefinition()
-
-		if hasSchemaSchema {
-			jsonSchemaAsText := step.JSONSchema.ToJSONString()
-			promptBuilder.AddValue("-", "SYSTEM", "JSON_SCHEMA", jsonSchemaAsText)
-		}
 
 		if promptBuilder.HasPlaceholders() {
 			stepGroups := promptBuilder.GroupPlaceholdersByStep()

--- a/step/prompt_step.go
+++ b/step/prompt_step.go
@@ -39,7 +39,7 @@ func (p *PromptStep) retryLLMGeneration(ctx context.Context, cfg *config.Config,
 }
 
 func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
-	maxResult := step.ResolvedMaxResults
+	maxResult := step.ResolvedCount
 	i := 0
 
 	// registerInvalid tracks consecutive invalid LLM responses; it returns a

--- a/step/prompt_step_test.go
+++ b/step/prompt_step_test.go
@@ -36,11 +36,11 @@ func promptStepConfig(t *testing.T, srvURL string) (*config.Config, config.Step,
 	cfg.OutputFolder = dir
 
 	step := config.Step{
-		Name:               "gen",
-		Type:               config.PromptStepType,
-		Prompt:             "generate something",
-		ResolvedMaxResults: 3,
-		OutputFilename:     filepath.Join(dir, "gen.jsonl"),
+		Name:           "gen",
+		Type:           config.PromptStepType,
+		Prompt:         "generate something",
+		ResolvedCount:  3,
+		OutputFilename: filepath.Join(dir, "gen.jsonl"),
 		ModelConfig: config.ModelConfig{
 			ModelProvider: llm.ProviderOllama,
 			ModelName:     "test-model",
@@ -57,7 +57,7 @@ func countLines(t *testing.T, path string) int {
 	return lines
 }
 
-func TestPromptStepRun_WritesMaxResultsLines(t *testing.T) {
+func TestPromptStepRun_WritesResolvedCountLines(t *testing.T) {
 	srv := llmtest.NewServer(t, "hello world")
 	cfg, step, dir := promptStepConfig(t, srv.URL)
 

--- a/utils/envexpand_test.go
+++ b/utils/envexpand_test.go
@@ -93,9 +93,9 @@ func TestExpandEnv(t *testing.T) {
 		},
 		{
 			name:    "datamatic internal syntax preserved",
-			input:   "maxResults: convert_to_jsonl.$length",
+			input:   "prompt: item costs $100, quantity $length",
 			envVars: map[string]string{},
-			want:    "maxResults: convert_to_jsonl.$length",
+			want:    "prompt: item costs $100, quantity $length",
 		},
 	}
 

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mirpo/datamatic/jsonschema"
 	"github.com/mirpo/datamatic/llm"
 	"github.com/mirpo/datamatic/promptbuilder"
+	"github.com/mirpo/datamatic/retry"
 )
 
 // setStepType determines and sets the step type based on step configuration
@@ -61,7 +62,13 @@ func PreprocessConfig(cfg *config.Config) error {
 		return fmt.Errorf("setting root output folder: %w", err)
 	}
 
+	// retryConfig not set in YAML (zero values) falls back to defaults
+	if cfg.RetryConfig.MaxAttempts == 0 {
+		cfg.RetryConfig = retry.NewDefaultConfig()
+	}
+
 	stepNames := make(map[string]bool, len(cfg.Steps))
+	stepByName := make(map[string]*config.Step, len(cfg.Steps))
 
 	for i := range cfg.Steps {
 		step := &cfg.Steps[i]
@@ -71,7 +78,7 @@ func PreprocessConfig(cfg *config.Config) error {
 			return fmt.Errorf("step at index %d: name can't be empty", i)
 		}
 		if strings.ToUpper(step.Name) == "SYSTEM" {
-			return fmt.Errorf("using 'SYSTEM' as step name is not allowed")
+			return fmt.Errorf("using 'SYSTEM' as step name is not allowed (reserved)")
 		}
 		if step.Name == promptbuilder.ItemAliasName {
 			return fmt.Errorf("using '%s' as step name is not allowed (reserved for forEach references)", promptbuilder.ItemAliasName)
@@ -160,12 +167,62 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Iteration settings (count / forEach)
+		// Iteration settings (count / forEach); resolves the {{.item}} alias,
+		// so placeholder validation below sees canonical references
 		if err := setIterationDefaults(step, stepNames); err != nil {
 			return fmt.Errorf("step '%s': %w", step.Name, err)
 		}
 
+		if step.Type == config.PromptStepType {
+			if err := validatePromptPlaceholders(step, stepByName); err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+		}
+
 		stepNames[step.Name] = true
+		stepByName[step.Name] = step
+	}
+
+	return nil
+}
+
+// validatePromptPlaceholders checks every {{.step.field}} reference in the
+// prompt against earlier steps: the step must exist, field references into
+// prompt steps must match their JSON schema, and a step may not be referenced
+// both as a whole and by field in one prompt.
+func validatePromptPlaceholders(step *config.Step, stepByName map[string]*config.Step) error {
+	builder := promptbuilder.NewPromptBuilder(step.Prompt)
+	if !builder.HasPlaceholders() {
+		return nil
+	}
+
+	keysByStep := map[string]map[bool]bool{} // step -> {isWhole -> seen}
+
+	for _, ref := range builder.GetPlaceholders() {
+		refStep, ok := stepByName[ref.Step]
+		if !ok {
+			return fmt.Errorf("prompt references unknown step '%s' (must be an earlier step)", ref.Step)
+		}
+
+		if keysByStep[ref.Step] == nil {
+			keysByStep[ref.Step] = map[bool]bool{}
+		}
+		keysByStep[ref.Step][ref.Key == ""] = true
+
+		if ref.Key != "" && refStep.Type == config.PromptStepType {
+			if !refStep.JSONSchema.HasSchemaDefinition() {
+				return fmt.Errorf("step '%s' must have a JSON schema to reference field '%s'", ref.Step, ref.Key)
+			}
+			if !refStep.JSONSchema.HasFieldPath(ref.Key) {
+				return fmt.Errorf("field path '%s' not found in step '%s' JSON schema", ref.Key, ref.Step)
+			}
+		}
+	}
+
+	for name, kinds := range keysByStep {
+		if kinds[true] && kinds[false] {
+			return fmt.Errorf("step '%s' is referenced both as a whole ({{.%s}}) and by field — use one style", name, name)
+		}
 	}
 
 	return nil

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mirpo/datamatic/jq"
 	"github.com/mirpo/datamatic/jsonschema"
 	"github.com/mirpo/datamatic/llm"
+	"github.com/mirpo/datamatic/promptbuilder"
 )
 
 // setStepType determines and sets the step type based on step configuration
@@ -72,6 +73,9 @@ func PreprocessConfig(cfg *config.Config) error {
 		if strings.ToUpper(step.Name) == "SYSTEM" {
 			return fmt.Errorf("using 'SYSTEM' as step name is not allowed")
 		}
+		if step.Name == promptbuilder.ItemAliasName {
+			return fmt.Errorf("using '%s' as step name is not allowed (reserved for forEach references)", promptbuilder.ItemAliasName)
+		}
 		if stepNames[step.Name] {
 			return fmt.Errorf("duplicate step name found: '%s'", step.Name)
 		}
@@ -131,9 +135,8 @@ func PreprocessConfig(cfg *config.Config) error {
 			if step.From == "" {
 				return fmt.Errorf("step '%s': 'from' is required for transform steps", step.Name)
 			}
-			// stepNames holds earlier steps only (this step registers below)
-			if !stepNames[step.From] {
-				return fmt.Errorf("step '%s': 'from' references unknown step '%s' (must be an earlier step)", step.Name, step.From)
+			if err := requireEarlierStep(stepNames, "from", step.From); err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
 			}
 			if step.Limit < 0 {
 				return fmt.Errorf("step '%s': limit must be >= 0", step.Name)
@@ -157,8 +160,8 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Apply MaxResults defaults
-		if err := setMaxResultsDefaults(step); err != nil {
+		// Iteration settings (count / forEach)
+		if err := setIterationDefaults(step, stepNames); err != nil {
 			return fmt.Errorf("step '%s': %w", step.Name, err)
 		}
 
@@ -246,31 +249,45 @@ func setImagePath(step *config.Step, outputFolder string) error {
 	return nil
 }
 
-// setMaxResultsDefaults sets default MaxResults for nil, empty string, and int <= 0 cases
-func setMaxResultsDefaults(step *config.Step) error {
-	switch v := step.MaxResults.(type) {
-	case nil:
-		step.MaxResults = config.DefaultStepMinMaxResults
-		return nil
+// requireEarlierStep checks that a cross-step reference points at an already
+// defined step. stepNames must hold earlier steps only.
+func requireEarlierStep(stepNames map[string]bool, field, name string) error {
+	if !stepNames[name] {
+		return fmt.Errorf("'%s' references unknown step '%s' (must be an earlier step)", field, name)
+	}
+	return nil
+}
 
-	case string:
-		if v == "" {
-			step.MaxResults = config.DefaultStepMinMaxResults
-			return nil
+// setIterationDefaults validates count/forEach and resolves the {{.item}}
+// alias to the forEach source, so every later consumer sees one canonical
+// prompt. Iteration counts themselves are resolved at runtime by the runner.
+func setIterationDefaults(step *config.Step, stepNames map[string]bool) error {
+	if step.Type != config.PromptStepType {
+		if step.Count != 0 || step.ForEach != "" {
+			return fmt.Errorf("'count' and 'forEach' are only valid on prompt steps")
 		}
-		// check dynamic strings (like "foo.$length") in validation phase
-		return nil
-
-	case int:
-		if v <= 0 {
-			step.MaxResults = config.DefaultStepMinMaxResults
-		}
-		// positive int values passed as-is
-		return nil
-
-	default:
 		return nil
 	}
+
+	if step.Count < 0 {
+		return fmt.Errorf("count must be >= 0")
+	}
+	if step.Count > 0 && step.ForEach != "" {
+		return fmt.Errorf("either 'count' or 'forEach' may be set, not both")
+	}
+	if step.ForEach != "" {
+		if err := requireEarlierStep(stepNames, "forEach", step.ForEach); err != nil {
+			return err
+		}
+	}
+
+	prompt, err := promptbuilder.ResolveItemAlias(step.Prompt, step.ForEach)
+	if err != nil {
+		return err
+	}
+	step.Prompt = prompt
+
+	return nil
 }
 
 // isValidName validates filename according to filesystem rules

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -56,25 +56,24 @@ func TestPreprocessConfig_Success(t *testing.T) {
 				Prompt:         "Generate something",
 				OutputFilename: "custom",
 				ImagePath:      "images/photo.jpg",
-				MaxResults:     nil, // should default
+				// no count/forEach: image step, iterations resolved at runtime
 			},
 			{
 				Name:           "cli1",
 				Run:            "echo hi",
 				OutputFilename: "cli1",
-				MaxResults:     -1, // should default
 			},
 			{
-				Name:       "prompt2",
-				Model:      "openai:gpt-4",
-				Prompt:     "More text",
-				MaxResults: 5,
+				Name:   "prompt2",
+				Model:  "openai:gpt-4",
+				Prompt: "More text",
+				Count:  5,
 			},
 			{
-				Name:       "prompt3",
-				Model:      "gemini:gemini-pro",
-				Prompt:     "Dynamic",
-				MaxResults: "prompt1.$length",
+				Name:    "prompt3",
+				Model:   "gemini:gemini-pro",
+				Prompt:  "Dynamic",
+				ForEach: "prompt1",
 			},
 		},
 	}
@@ -103,11 +102,12 @@ func TestPreprocessConfig_Success(t *testing.T) {
 	expectedImage, _ := filepath.Abs(filepath.Join(outputFolder, "images", "photo.jpg"))
 	assert.Equal(t, expectedImage, cfg.Steps[0].ImagePath)
 
-	// MaxResults
-	assert.Equal(t, config.DefaultStepMinMaxResults, cfg.Steps[0].MaxResults)
-	assert.Equal(t, config.DefaultStepMinMaxResults, cfg.Steps[1].MaxResults)
-	assert.Equal(t, 5, cfg.Steps[2].MaxResults)
-	assert.Equal(t, "prompt1.$length", cfg.Steps[3].MaxResults)
+	// Iteration settings
+	assert.Equal(t, 0, cfg.Steps[0].Count, "image step: iterations resolved at runtime, no default count")
+	assert.Equal(t, 0, cfg.Steps[1].Count, "shell steps have no count")
+	assert.Equal(t, 5, cfg.Steps[2].Count)
+	assert.Equal(t, "prompt1", cfg.Steps[3].ForEach)
+	assert.Equal(t, 0, cfg.Steps[3].Count)
 }
 
 func TestSetWorkDir(t *testing.T) {
@@ -302,5 +302,82 @@ func TestPreprocessConfig_TransformStep(t *testing.T) {
 		cfg.Steps[1].Limit = -1
 		err := PreprocessConfig(cfg)
 		assert.ErrorContains(t, err, "limit")
+	})
+}
+
+func TestPreprocessConfig_CountAndForEach(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "seed", Prompt: "p", Model: "ollama:m", Count: 2},
+			{Name: "per_row", Prompt: "use {{.item}}", Model: "ollama:m", ForEach: "seed"},
+		}
+		return cfg
+	}
+
+	t.Run("valid count and forEach pass", func(t *testing.T) {
+		cfg := base()
+		assert.NoError(t, PreprocessConfig(cfg))
+	})
+
+	t.Run("generator count stays 0 (default applied at runtime)", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Count = 0
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, 0, cfg.Steps[0].Count, "runner.resolveIterations owns the default")
+	})
+
+	t.Run("item alias rewritten to forEach source", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Prompt = "use {{.item.title}} and {{.item}}"
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, "use {{.seed.title}} and {{.seed}}", cfg.Steps[1].Prompt)
+	})
+
+	t.Run("item without forEach fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].ForEach = ""
+		cfg.Steps[1].Count = 2
+		assert.ErrorContains(t, PreprocessConfig(cfg), "no forEach")
+	})
+
+	t.Run("count and forEach together fail", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Count = 5
+		assert.ErrorContains(t, PreprocessConfig(cfg), "either 'count' or 'forEach'")
+	})
+
+	t.Run("forEach referencing unknown step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].ForEach = "ghost"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "unknown step 'ghost'")
+	})
+
+	t.Run("forEach referencing itself fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].ForEach = "per_row"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "unknown step 'per_row'")
+	})
+
+	t.Run("negative count fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Count = -1
+		assert.ErrorContains(t, PreprocessConfig(cfg), "count")
+	})
+
+	t.Run("forEach on shell step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{
+			Name: "sh", Run: "echo hi > x.jsonl", OutputFilename: "x.jsonl", ForEach: "seed",
+		})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "forEach")
+	})
+
+	t.Run("step named item is reserved", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Name = "item"
+		cfg.Steps[1].ForEach = "item"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "not allowed")
 	})
 }

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -330,9 +330,15 @@ func TestPreprocessConfig_CountAndForEach(t *testing.T) {
 
 	t.Run("item alias rewritten to forEach source", func(t *testing.T) {
 		cfg := base()
-		cfg.Steps[1].Prompt = "use {{.item.title}} and {{.item}}"
+		cfg.Steps[0].JSONSchemaRaw = `{
+			"type": "object",
+			"properties": {"title": {"type": "string"}, "tag": {"type": "string"}},
+			"required": ["title", "tag"],
+			"additionalProperties": false
+		}`
+		cfg.Steps[1].Prompt = "use {{.item.title}} and {{.item.tag}}"
 		assert.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, "use {{.seed.title}} and {{.seed}}", cfg.Steps[1].Prompt)
+		assert.Equal(t, "use {{.seed.title}} and {{.seed.tag}}", cfg.Steps[1].Prompt)
 	})
 
 	t.Run("item without forEach fails", func(t *testing.T) {
@@ -379,5 +385,65 @@ func TestPreprocessConfig_CountAndForEach(t *testing.T) {
 		cfg.Steps[0].Name = "item"
 		cfg.Steps[1].ForEach = "item"
 		assert.ErrorContains(t, PreprocessConfig(cfg), "not allowed")
+	})
+}
+
+func TestPreprocessConfig_PromptPlaceholders(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{
+				Name: "src", Prompt: "gen", Model: "ollama:m", Count: 2,
+				JSONSchemaRaw: `{
+					"type": "object",
+					"properties": {"title": {"type": "string"}},
+					"required": ["title"],
+					"additionalProperties": false
+				}`,
+			},
+			{Name: "use", Prompt: "x {{.src.title}}", Model: "ollama:m", ForEach: "src"},
+		}
+		return cfg
+	}
+
+	t.Run("valid cross-step reference passes", func(t *testing.T) {
+		assert.NoError(t, PreprocessConfig(base()))
+	})
+
+	t.Run("SYSTEM placeholder is rejected (feature removed)", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Prompt = "follow this schema: {{.SYSTEM.JSON_SCHEMA}}"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "unknown step 'SYSTEM'")
+	})
+
+	t.Run("self reference fails at config time", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Prompt = "continue {{.use}}"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "unknown step 'use'")
+	})
+
+	t.Run("reference to later step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Prompt = "peek ahead {{.use.title}}"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "unknown step 'use'")
+	})
+
+	t.Run("field missing from source schema fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Prompt = "x {{.src.nope}}"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "nope")
+	})
+
+	t.Run("field reference to schema-less prompt step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].JSONSchemaRaw = nil
+		assert.ErrorContains(t, PreprocessConfig(cfg), "JSON schema")
+	})
+
+	t.Run("mixing whole and field references to one step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Prompt = "all: {{.src}} title: {{.src.title}}"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "both as a whole")
 	})
 }


### PR DESCRIPTION
## Summary

Two commits replacing the implicit iteration model and tightening config validation.

### 1. `count:` / `forEach:` replace `maxResults` / `$length` (2c56881)

```yaml
- name: seed
  count: 5               # generator: produce 5 rows
- name: per_row
  forEach: seed           # one iteration per row of an earlier step
  prompt: "... {{.item.field}} ..."
```

- Typed `Count`/`ForEach` fields replace `MaxResults interface{}`; `$length` parsing and its validation deleted
- `{{.item}}` alias resolved once during preprocessing; `item` is a reserved step name
- The whole iteration decision (forEach rows / image glob / count / default) lives in one place, `runner.resolveIterations`
- Image steps no longer need a decoy `maxResults: X.$length` — `imagePath` without count/forEach iterates the matched files
- **Strict YAML parsing** (`KnownFields`): unknown keys (typos, removed syntax) are config errors instead of silently ignored
- All 19 examples migrated in place; CI example run updated

### 2. Review-driven validation/DDD cleanup (this commit)

- **All cross-step placeholder checks moved to preprocessing** with one earlier-steps registry: self-references and forward references now fail at config load with a clear message (before: passed validation, died at runtime with `file is empty`); mixing `{{.step}}` and `{{.step.field}}` is rejected
- **`{{.SYSTEM.JSON_SCHEMA}}` feature removed**: the schema already reaches models via `response_format` (constrained decoding); official [Ollama guidance](https://ollama.com/blog/structured-outputs) recommends only a short "return as JSON" hint. The placeholder was actually rejected by validation and unused by all examples
- `Validate()` is side-effect free: interactive CLI warning moved to `main`, retry defaults to preprocessing
- Example fixes: contradictory instructions (4), stale "schema below" wording (3/14/17), doubled `prompt: |` (7), example 6's first jq CLI step → built-in transform

## Verified live (local ollama)

- Example 3: `count: 10` → 10 countries, `forEach` → 10 brochures (rerun after prompt updates)
- Example 8 smoke (qwen2.5vl vision): `imagePath` iteration → 3 images → LaTeX → `forEach` explanations
- Example 19: fan-out chain with `{{.item.name}}`/`{{.item.role}}`
- Self-reference and SYSTEM configs fail at config time with clear errors

## Test plan
- [x] `go test ./...` — 13 packages green (new: placeholder-validation table, count/forEach preprocessing, `.item` rewrite, strict-YAML rejection, e2e transform pipeline)
- [x] `golangci-lint run` — 0 issues
- [x] `GOOS=windows go build` ok
- [x] All 19 example configs validate via `TestValidateConfigFromExamples`