### PR TITLE
feat: transform fan-in (collect) and lineage access ($parent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ steps:
 
 - `from` — source step; the jq program sees each row's value (for prompt steps: the `response`)
 - `jq` — any jq program; emitting multiple values fans out (1 row → N rows), `select()` filters rows out
+- `collect: true` — fan-in: the program runs once over an **array of all source rows** (`unique`, `group_by`, `sort_by` across the whole dataset)
+- `$parent` — per-row programs can reach the source row's lineage as `$parent.step.field` (e.g. carry the original chunk while fanning out extracted questions); not available with `collect`, where there is no single parent row
 - `limit` — optional cap on output rows
+
+Always wrap jq programs in single quotes: unquoted YAML silently truncates at `#`, misparses `{...}` object construction, and jq's own strings use double quotes anyway.
 
 jq programs are validated when the config loads. Transform steps run instantly, produce regular JSONL, and don't trigger the external-CLI warning. See the [Fan-Out example](./examples/v1/19.%20transform%20step%20and%20fan-out/README.md).
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ steps:
 - `from` — source step; the jq program sees each row's value (for prompt steps: the `response`)
 - `jq` — any jq program; emitting multiple values fans out (1 row → N rows), `select()` filters rows out
 - `collect: true` — fan-in: the program runs once over an **array of all source rows** (`unique`, `group_by`, `sort_by` across the whole dataset)
+- `sourceFormat: json` — the source file is a single JSON value (e.g. a pretty-printed array from an API dump) instead of JSONL
 - `$parent` — per-row programs can reach the source row's lineage as `$parent.step.field` (e.g. carry the original chunk while fanning out extracted questions); not available with `collect`, where there is no single parent row
 - `limit` — optional cap on output rows
 

--- a/config/config.go
+++ b/config/config.go
@@ -51,16 +51,22 @@ const (
 	UnknownStepType   StepType = "unknown"
 )
 
+const (
+	SourceFormatJSONL = "jsonl" // one JSON value per line (default)
+	SourceFormatJSON  = "json"  // the whole file is a single JSON value
+)
+
 type Step struct {
 	Type           StepType    `yaml:"type,omitempty"`
 	Name           string      `yaml:"name"`
 	Model          string      `yaml:"model"`
 	Prompt         string      `yaml:"prompt"`
 	Run            string      `yaml:"run"`
-	JQ             string      `yaml:"jq"`      // transform steps: jq program
-	From           string      `yaml:"from"`    // transform steps: source step name
-	Limit          int         `yaml:"limit"`   // transform steps: cap output rows (0 = no cap)
-	Collect        bool        `yaml:"collect"` // transform steps: jq sees an array of ALL source rows (fan-in)
+	JQ             string      `yaml:"jq"`           // transform steps: jq program
+	From           string      `yaml:"from"`         // transform steps: source step name
+	Limit          int         `yaml:"limit"`        // transform steps: cap output rows (0 = no cap)
+	Collect        bool        `yaml:"collect"`      // transform steps: jq sees an array of ALL source rows (fan-in)
+	SourceFormat   string      `yaml:"sourceFormat"` // transform steps: "jsonl" (default, line per row) or "json" (whole file is one value)
 	WorkDir        string      `yaml:"workDir,omitempty"`
 	SystemPrompt   string      `yaml:"systemPrompt"`
 	Count          int         `yaml:"count"`   // generator steps: how many rows to produce (default 3)

--- a/config/config.go
+++ b/config/config.go
@@ -57,9 +57,10 @@ type Step struct {
 	Model          string      `yaml:"model"`
 	Prompt         string      `yaml:"prompt"`
 	Run            string      `yaml:"run"`
-	JQ             string      `yaml:"jq"`    // transform steps: jq program
-	From           string      `yaml:"from"`  // transform steps: source step name
-	Limit          int         `yaml:"limit"` // transform steps: cap output rows (0 = no cap)
+	JQ             string      `yaml:"jq"`      // transform steps: jq program
+	From           string      `yaml:"from"`    // transform steps: source step name
+	Limit          int         `yaml:"limit"`   // transform steps: cap output rows (0 = no cap)
+	Collect        bool        `yaml:"collect"` // transform steps: jq sees an array of ALL source rows (fan-in)
 	WorkDir        string      `yaml:"workDir,omitempty"`
 	SystemPrompt   string      `yaml:"systemPrompt"`
 	Count          int         `yaml:"count"`   // generator steps: how many rows to produce (default 3)
@@ -70,8 +71,10 @@ type Step struct {
 	ImagePath      string      `yaml:"imagePath"`
 	ResolvedCount  int
 	JSONSchema     jsonschema.Schema
-	// JQProgram holds the compiled jq program (set during preprocessing)
-	JQProgram *jq.Program
+	// JQProgram holds the compiled jq program (set during preprocessing);
+	// UsesParent records whether it references the $parent variable
+	JQProgram  *jq.Program
+	UsesParent bool
 }
 
 type ModelConfig struct {

--- a/examples/v1/15. simple math reasoning/config.yaml
+++ b/examples/v1/15. simple math reasoning/config.yaml
@@ -7,11 +7,12 @@ steps:
       hf download --repo-type dataset TIGER-Lab/MathInstruct --local-dir ./ --include MathInstruct.json
     outputFilename: MathInstruct.json
 
+  # the download is a pretty-printed JSON array — sourceFormat: json reads
+  # it as one value, no external jq needed
   - name: math_problems_10
-    type: shell
-    run: |
-      jq -c '.[:10][]' ./MathInstruct.json > ./10_math_problems.jsonl
-    outputFilename: 10_math_problems.jsonl
+    from: download_dataset
+    sourceFormat: json
+    jq: '.[:10][]'
 
   - name: solve_with_reasoning
     type: prompt

--- a/examples/v1/17. document classification with schema-guided reasoning/config.yaml
+++ b/examples/v1/17. document classification with schema-guided reasoning/config.yaml
@@ -109,3 +109,9 @@ steps:
         - brief_summary
         - key_entities_mentioned
         - keywords
+
+  # fan-in QA: label distribution of the generated dataset in one expression
+  - name: label_distribution
+    from: classify_documents
+    collect: true
+    jq: 'group_by(.document_type) | map({document_type: .[0].document_type, count: length}) | sort_by(-.count) | .[]'

--- a/examples/v1/6. git dataset/config.yaml
+++ b/examples/v1/6. git dataset/config.yaml
@@ -49,13 +49,12 @@ steps:
       required:
         - instructions
 
-  # stays a shell step: dedupe ACROSS rows needs the whole file at once,
-  # which per-row transform steps can't do yet (fan-in)
+  # fan-in: collect gives jq an array of ALL rows, so cross-row dedupe
+  # is one expression — no external jq, no envelope digging
   - name: split_into_unique_instructions
-    type: shell
-    run: |
-      cat ./generate_instructions.jsonl | jq -c '.response.instructions[]' | sort | uniq | jq -c '{id: . | @base64, instruction: .}' > ./split_into_unique_instructions.jsonl
-    outputFilename: split_into_unique_instructions.jsonl
+    from: generate_instructions
+    collect: true
+    jq: 'map(.instructions[]) | unique[] | {id: @base64, instruction: .}'
 
   - name: generate_answer
     model: ollama:llama3.2
@@ -70,11 +69,10 @@ steps:
       Instruction: "{{.split_into_unique_instructions.instruction}}"
     forEach: split_into_unique_instructions
 
+  # join the generated answer with its source instruction via $parent
   - name: instruction_response
-    type: shell
-    run: |
-      cat ./generate_answer.jsonl | jq -c '{instruction: .values.".split_into_unique_instructions.instruction".value, response: .response}' > ./instruction_response.jsonl
-    outputFilename: instruction_response.jsonl
+    from: generate_answer
+    jq: '{instruction: $parent.split_into_unique_instructions.instruction, response: .}' 
 
   - name: rate
     model: ollama:llama3.2
@@ -164,8 +162,8 @@ steps:
         - complexity
         - verbosity
 
+  # final dataset rows; note: the old shell version wrote response into
+  # both fields — fixed here via $parent
   - name: result
-    type: shell
-    run: |
-      cat ./rate.jsonl | jq -c '{instruction: .values.".instruction_response.response".value, response: .values.".instruction_response.response".value, evaluation: .response}' > result.jsonl
-    outputFilename: result.jsonl
+    from: rate
+    jq: '{instruction: $parent.instruction_response.instruction, response: $parent.instruction_response.response, evaluation: .}' 

--- a/examples/v1/7. fine-tuning dataset/config.yaml
+++ b/examples/v1/7. fine-tuning dataset/config.yaml
@@ -63,11 +63,10 @@ steps:
       required:
         - questions
 
+  # fan-out questions while carrying the source chunk from lineage ($parent)
   - name: flatten_question_chunk
-    type: shell
-    run: |
-      cat ./questions_per_chunk.jsonl | jq -c '.values.".chopdoc_by_sentence.chunk".value as $chunk | .response.questions[] | { question: .question, chunk: $chunk, textEvidence: .textEvidence}' > flatten_question_chunk.jsonl
-    outputFilename: flatten_question_chunk.jsonl
+    from: questions_per_chunk
+    jq: '.questions[] | {question, chunk: $parent.chopdoc_by_sentence.chunk, textEvidence}' 
 
   - name: validate_questions
     model: ollama:deepseek-r1:1.5b
@@ -114,8 +113,7 @@ steps:
       required:
         - rating
 
+  # keep only well-rated pairs; the QA fields come from the parent row
   - name: filter_with_high_rating
-    type: shell
-    run: |
-      cat ./validate_questions.jsonl | jq -c '. | select(.response.rating >= 7)' > filter_with_high_rating.jsonl
-    outputFilename: filter_with_high_rating.jsonl
+    from: validate_questions
+    jq: 'select(.rating >= 7) | $parent.flatten_question_chunk + {rating: .rating}' 

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -7,19 +7,31 @@ import (
 	"github.com/itchyny/gojq"
 )
 
+// ParentVar is the variable name per-row transform programs may declare to
+// access the source row's lineage (see jsonl.UnfoldLineage for its shape).
+const ParentVar = "$parent"
+
 type Program struct {
 	source string
 	code   *gojq.Code
 }
 
 // Compile parses and compiles a jq program; errors are config-time errors.
-func Compile(source string) (*Program, error) {
+// Optional variable names (e.g. "$parent") declare named variables whose
+// values are passed positionally to Run/RunEach; using an undeclared
+// variable in the program fails here, at compile time.
+func Compile(source string, variables ...string) (*Program, error) {
 	query, err := gojq.Parse(source)
 	if err != nil {
 		return nil, fmt.Errorf("invalid jq program %q: %w", source, err)
 	}
 
-	code, err := gojq.Compile(query)
+	var opts []gojq.CompilerOption
+	if len(variables) > 0 {
+		opts = append(opts, gojq.WithVariables(variables))
+	}
+
+	code, err := gojq.Compile(query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile jq program %q: %w", source, err)
 	}
@@ -29,20 +41,35 @@ func Compile(source string) (*Program, error) {
 
 // Run applies the program to one input value and returns all emitted values
 // (0..N — select() filters to 0, .items[] fans out to N).
-func (p *Program) Run(input interface{}) ([]interface{}, error) {
+func (p *Program) Run(input interface{}, variableValues ...interface{}) ([]interface{}, error) {
 	var results []interface{}
+	err := p.RunEach(input, func(v interface{}) (bool, error) {
+		results = append(results, v)
+		return false, nil
+	}, variableValues...)
+	return results, err
+}
 
-	iter := p.code.Run(input)
+// RunEach applies the program and streams emitted values to emit; emit
+// returning stop=true ends iteration early without materializing the rest.
+// variableValues match the variables declared at Compile, in order.
+func (p *Program) RunEach(input interface{}, emit func(v interface{}) (stop bool, err error), variableValues ...interface{}) error {
+	iter := p.code.Run(input, variableValues...)
 	for {
 		v, ok := iter.Next()
 		if !ok {
-			break
+			return nil
 		}
 		if err, isErr := v.(error); isErr {
-			return nil, fmt.Errorf("jq program %q failed: %w", p.source, err)
+			return fmt.Errorf("jq program %q failed: %w", p.source, err)
 		}
-		results = append(results, v)
-	}
 
-	return results, nil
+		stop, err := emit(v)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
 }

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -7,10 +7,6 @@ import (
 	"github.com/itchyny/gojq"
 )
 
-// ParentVar is the variable name per-row transform programs may declare to
-// access the source row's lineage (see jsonl.UnfoldLineage for its shape).
-const ParentVar = "$parent"
-
 type Program struct {
 	source string
 	code   *gojq.Code

--- a/jq/jq_test.go
+++ b/jq/jq_test.go
@@ -55,3 +55,55 @@ func TestRun_RuntimeErrorSurfaces(t *testing.T) {
 	_, err = p.Run(map[string]interface{}{"a": "not-a-number"})
 	assert.Error(t, err)
 }
+
+func TestRunEach_StopsEarly(t *testing.T) {
+	p, err := Compile(`.[]`)
+	require.NoError(t, err)
+
+	var got []interface{}
+	err = p.RunEach([]interface{}{"a", "b", "c", "d"}, func(v interface{}) (bool, error) {
+		got = append(got, v)
+		return len(got) == 2, nil // stop after two
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"a", "b"}, got)
+}
+
+func TestRunEach_PropagatesEmitError(t *testing.T) {
+	p, err := Compile(`.[]`)
+	require.NoError(t, err)
+
+	err = p.RunEach([]interface{}{"a"}, func(v interface{}) (bool, error) {
+		return false, assert.AnError
+	})
+
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestCompileWithVariables_ParentAccessible(t *testing.T) {
+	p, err := Compile(`{q: .q, chunk: $parent.chop.chunk}`, "$parent")
+	require.NoError(t, err)
+
+	out, err := p.Run(
+		map[string]interface{}{"q": "why?"},
+		map[string]interface{}{"chop": map[string]interface{}{"chunk": "source text"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{map[string]interface{}{"q": "why?", "chunk": "source text"}}, out)
+}
+
+func TestCompile_UndeclaredVariableFailsAtCompile(t *testing.T) {
+	_, err := Compile(`{chunk: $parent.chunk}`) // $parent not declared
+	assert.Error(t, err, "using $parent without declaring it must be a compile-time error")
+	assert.Contains(t, err.Error(), "$parent")
+}
+
+func TestCompileWithVariables_NullParentIsFine(t *testing.T) {
+	p, err := Compile(`.v`, "$parent")
+	require.NoError(t, err)
+
+	out, err := p.Run(map[string]interface{}{"v": 1}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{1}, out)
+}

--- a/jsonl/line.go
+++ b/jsonl/line.go
@@ -52,3 +52,30 @@ func NewLineEntity(response string, prompt string, isJSON bool, values map[strin
 		Values:   values,
 	}, nil
 }
+
+// UnfoldLineage turns lineage keys (".step.field.path") into a nested plain
+// map so jq programs can reach them naturally: $parent.step.field.path.
+// Plain map[string]interface{} nodes are required by gojq (it type-switches
+// on exactly that type), so this deliberately does not reuse promptbuilder's
+// Object-building helpers. Returns untyped nil when there is no lineage.
+func UnfoldLineage(values map[string]promptbuilder.ValueShort) interface{} {
+	if len(values) == 0 {
+		return nil
+	}
+
+	parent := make(map[string]interface{})
+	for key, v := range values {
+		parts := strings.Split(strings.TrimPrefix(key, "."), ".")
+		current := parent
+		for _, part := range parts[:len(parts)-1] {
+			next, ok := current[part].(map[string]interface{})
+			if !ok {
+				next = make(map[string]interface{})
+				current[part] = next
+			}
+			current = next
+		}
+		current[parts[len(parts)-1]] = v.Value
+	}
+	return parent
+}

--- a/jsonl/line_test.go
+++ b/jsonl/line_test.go
@@ -144,3 +144,25 @@ func TestNewJSONLineEntityError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestUnfoldLineage(t *testing.T) {
+	t.Run("keys unfold into nested plain maps", func(t *testing.T) {
+		parent := UnfoldLineage(map[string]promptbuilder.ValueShort{
+			".chopdoc.chunk": {ID: "c1", Value: "source text"},
+			".chopdoc.n":     {ID: "c1", Value: 7},
+			".other":         {ID: "o1", Value: "whole"},
+		})
+
+		m := parent.(map[string]interface{})
+		chop := m["chopdoc"].(map[string]interface{})
+		assert.Equal(t, "source text", chop["chunk"])
+		assert.Equal(t, 7, chop["n"])
+		assert.Equal(t, "whole", m["other"])
+	})
+
+	t.Run("empty lineage is untyped nil", func(t *testing.T) {
+		assert.Nil(t, UnfoldLineage(nil))
+		parent := UnfoldLineage(map[string]promptbuilder.ValueShort{})
+		assert.True(t, parent == nil, "must be untyped nil so $parent renders as jq null")
+	})
+}

--- a/step/stepdata.go
+++ b/step/stepdata.go
@@ -18,34 +18,37 @@ func uuidFromString(input string) string {
 	return uuid.NewMD5(uuid.NameSpaceOID, []byte(input)).String()
 }
 
-// getSourceDataFromLine extracts the data and record ID from a step line
-// Shell steps: full line is an unknown JSON
-// Prompt steps: line contains JSON created with datamatic
-func getSourceDataFromLine(step config.Step, line string) (interface{}, string, error) {
+// getSourceDataFromLine extracts the data, record ID and raw lineage values
+// from a step line.
+// Shell steps: full line is an unknown JSON, no lineage.
+// Prompt steps: line is a datamatic LineEntity — data is the response;
+// lineage values come back as-is (unfold them lazily via jsonl.UnfoldLineage).
+// Transform steps: full line is a raw JSON value, no lineage.
+func getSourceDataFromLine(step config.Step, line string) (interface{}, string, map[string]promptbuilder.ValueShort, error) {
 	switch step.Type {
 	case config.ShellStepType:
 		var decoded map[string]interface{}
 		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
-			return nil, "", fmt.Errorf("shell step: failed to parse JSON: %w", err)
+			return nil, "", nil, fmt.Errorf("shell step: failed to parse JSON: %w", err)
 		}
-		return decoded, "", nil
+		return decoded, "", nil, nil
 
 	case config.PromptStepType:
 		var decoded jsonl.LineEntity
 		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
-			return nil, "", fmt.Errorf("prompt step: failed to parse JSON: %w", err)
+			return nil, "", nil, fmt.Errorf("prompt step: failed to parse JSON: %w", err)
 		}
-		return decoded.Response, decoded.ID, nil
+		return decoded.Response, decoded.ID, decoded.Values, nil
 
 	case config.TransformStepType:
 		var decoded interface{}
 		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
-			return nil, "", fmt.Errorf("transform step: failed to parse JSON: %w", err)
+			return nil, "", nil, fmt.Errorf("transform step: failed to parse JSON: %w", err)
 		}
-		return decoded, "", nil
+		return decoded, "", nil, nil
 
 	default:
-		return nil, "", fmt.Errorf("unsupported step type '%s'", step.Type)
+		return nil, "", nil, fmt.Errorf("unsupported step type '%s'", step.Type)
 	}
 }
 
@@ -86,7 +89,7 @@ func readStepValuesBatch(step config.Step, outputFolder string, lineNumber int, 
 		return nil, err
 	}
 
-	sourceData, recordID, err := getSourceDataFromLine(step, line)
+	sourceData, recordID, _, err := getSourceDataFromLine(step, line)
 	if err != nil {
 		return nil, fmt.Errorf("line %d: %w", lineNumber, err)
 	}

--- a/step/stepdata_test.go
+++ b/step/stepdata_test.go
@@ -94,7 +94,7 @@ func TestGetSourceDataFromLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotData, gotID, err := getSourceDataFromLine(tt.step, tt.line)
+			gotData, gotID, _, err := getSourceDataFromLine(tt.step, tt.line)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -242,4 +242,22 @@ func TestExtractFieldByPath(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestGetSourceDataFromLine_LineageValues(t *testing.T) {
+	t.Run("prompt row returns raw lineage values", func(t *testing.T) {
+		line := `{"id":"r1","format":"json","prompt":"p","response":{"ok":true},` +
+			`"values":{".chopdoc.chunk":{"id":"c1","value":"source text"}}}`
+
+		_, _, lineage, err := getSourceDataFromLine(config.Step{Type: config.PromptStepType}, line)
+
+		require.NoError(t, err)
+		assert.Equal(t, "source text", lineage[".chopdoc.chunk"].Value)
+	})
+
+	t.Run("shell row has no lineage", func(t *testing.T) {
+		_, _, lineage, err := getSourceDataFromLine(config.Step{Type: config.ShellStepType}, `{"a":1}`)
+		require.NoError(t, err)
+		assert.Nil(t, lineage)
+	})
 }

--- a/step/transform_step.go
+++ b/step/transform_step.go
@@ -2,6 +2,7 @@ package step
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -20,22 +21,58 @@ func (p *TransformStep) Run(ctx context.Context, cfg *config.Config, step config
 		return fmt.Errorf("'from' references unknown step '%s'", step.From)
 	}
 
-	src, err := os.Open(srcStep.OutputFilename)
-	if err != nil {
-		return fmt.Errorf("failed to open source '%s': %w", srcStep.OutputFilename, err)
-	}
-	defer src.Close()
-
 	writer, err := jsonl.NewWriter(step.OutputFilename)
 	if err != nil {
 		return fmt.Errorf("failed to create JSONL writer: %w", err)
 	}
 	defer writer.Close()
 
+	if step.SourceFormat == config.SourceFormatJSON {
+		return runWholeJSON(step, srcStep.OutputFilename, writer)
+	}
+
+	src, err := os.Open(srcStep.OutputFilename)
+	if err != nil {
+		return fmt.Errorf("failed to open source '%s': %w", srcStep.OutputFilename, err)
+	}
+	defer src.Close()
+
 	if step.Collect {
 		return runCollect(ctx, *srcStep, step, src, writer)
 	}
 	return runPerRow(ctx, *srcStep, step, src, writer)
+}
+
+// runWholeJSON decodes the source file as a single JSON value (e.g. a
+// pretty-printed array from an API dump) and runs the program once over it.
+func runWholeJSON(step config.Step, path string, writer *jsonl.Writer) error {
+	data, err := os.ReadFile(path) // presized by file stat, unlike io.ReadAll
+	if err != nil {
+		return fmt.Errorf("failed to read source: %w", err)
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("sourceFormat json: failed to parse source: %w", err)
+	}
+
+	written := 0
+	if err := runProgram(step, value, limitedEmit(writer, step.Limit, &written), nil); err != nil {
+		return err
+	}
+
+	log.Info().Msgf("transform produced %d rows", written)
+	return nil
+}
+
+// runProgram runs the compiled program over one input, passing $parent only
+// when it was declared at compile time (the argument count must match the
+// variables declared in preprocessing).
+func runProgram(step config.Step, input interface{}, emit func(interface{}) (bool, error), parent interface{}) error {
+	if step.UsesParent {
+		return step.JQProgram.RunEach(input, emit, parent)
+	}
+	return step.JQProgram.RunEach(input, emit)
 }
 
 // runPerRow streams the source: the jq program runs once per row, each
@@ -59,12 +96,7 @@ func runPerRow(ctx context.Context, srcStep config.Step, step config.Step, src i
 			return fmt.Errorf("line %d: %w", lineNo, err)
 		}
 
-		if step.UsesParent {
-			err = step.JQProgram.RunEach(value, emit, jsonl.UnfoldLineage(lineage))
-		} else {
-			err = step.JQProgram.RunEach(value, emit)
-		}
-		if err != nil {
+		if err := runProgram(step, value, emit, jsonl.UnfoldLineage(lineage)); err != nil {
 			return fmt.Errorf("line %d: %w", lineNo, err)
 		}
 	}

--- a/step/transform_step.go
+++ b/step/transform_step.go
@@ -3,6 +3,7 @@ package step
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/mirpo/datamatic/config"
@@ -31,7 +32,18 @@ func (p *TransformStep) Run(ctx context.Context, cfg *config.Config, step config
 	}
 	defer writer.Close()
 
+	if step.Collect {
+		return runCollect(ctx, *srcStep, step, src, writer)
+	}
+	return runPerRow(ctx, *srcStep, step, src, writer)
+}
+
+// runPerRow streams the source: the jq program runs once per row, each
+// emitted value becomes an output row (fan-out), limit caps output.
+func runPerRow(ctx context.Context, srcStep config.Step, step config.Step, src io.Reader, writer *jsonl.Writer) error {
 	written := 0
+	emit := limitedEmit(writer, step.Limit, &written)
+
 	scanner := fs.NewLineScanner(src)
 	for lineNo := 0; scanner.Scan(); lineNo++ {
 		if err := ctx.Err(); err != nil {
@@ -42,24 +54,18 @@ func (p *TransformStep) Run(ctx context.Context, cfg *config.Config, step config
 			return nil
 		}
 
-		value, _, err := getSourceDataFromLine(*srcStep, scanner.Text())
+		value, _, lineage, err := getSourceDataFromLine(srcStep, scanner.Text())
 		if err != nil {
 			return fmt.Errorf("line %d: %w", lineNo, err)
 		}
 
-		results, err := step.JQProgram.Run(value)
+		if step.UsesParent {
+			err = step.JQProgram.RunEach(value, emit, jsonl.UnfoldLineage(lineage))
+		} else {
+			err = step.JQProgram.RunEach(value, emit)
+		}
 		if err != nil {
 			return fmt.Errorf("line %d: %w", lineNo, err)
-		}
-
-		for _, result := range results {
-			if step.Limit > 0 && written >= step.Limit {
-				break // mid-fan-out cap; outer check stops the scan
-			}
-			if err := writer.WriteJSON(result); err != nil {
-				return fmt.Errorf("failed to write output line: %w", err)
-			}
-			written++
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -68,4 +74,49 @@ func (p *TransformStep) Run(ctx context.Context, cfg *config.Config, step config
 
 	log.Info().Msgf("transform produced %d rows", written)
 	return nil
+}
+
+// runCollect gathers all source rows into one array and runs the jq program
+// once over it (fan-in: unique, group_by, sort_by across the whole dataset).
+func runCollect(ctx context.Context, srcStep config.Step, step config.Step, src io.Reader, writer *jsonl.Writer) error {
+	var collected []interface{}
+	scanner := fs.NewLineScanner(src)
+	for lineNo := 0; scanner.Scan(); lineNo++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		value, _, _, err := getSourceDataFromLine(srcStep, scanner.Text())
+		if err != nil {
+			return fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		collected = append(collected, value)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read source: %w", err)
+	}
+
+	written := 0
+	if err := step.JQProgram.RunEach(collected, limitedEmit(writer, step.Limit, &written)); err != nil {
+		return fmt.Errorf("collect: %w", err)
+	}
+
+	log.Info().Msgf("transform produced %d rows", written)
+	return nil
+}
+
+// limitedEmit returns a RunEach callback that writes emitted values until the
+// output limit is reached (0 = no limit).
+func limitedEmit(writer *jsonl.Writer, limit int, written *int) func(interface{}) (bool, error) {
+	return func(v interface{}) (bool, error) {
+		if limit > 0 && *written >= limit {
+			return true, nil
+		}
+		if err := writer.WriteJSON(v); err != nil {
+			return false, fmt.Errorf("failed to write output line: %w", err)
+		}
+		*written++
+		return false, nil
+	}
 }

--- a/step/transform_step_test.go
+++ b/step/transform_step_test.go
@@ -13,11 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mustCompile(t *testing.T, program string) *jq.Program {
+func mustCompile(t *testing.T, program string, vars ...string) *jq.Program {
 	t.Helper()
-	p, err := jq.Compile(program)
+	p, err := jq.Compile(program, vars...)
 	require.NoError(t, err)
 	return p
+}
+
+// collectFixture is transformFixture in collect mode: the program is compiled
+// without $parent (collect programs see an array of rows, no single parent).
+func collectFixture(t *testing.T, sourceType config.StepType, sourceLines string, program string, limit int) (*config.Config, config.Step) {
+	t.Helper()
+	cfg, step := transformFixture(t, sourceType, sourceLines, program, limit)
+	step.Collect = true
+	step.UsesParent = false
+	step.JQProgram = mustCompile(t, program)
+	return cfg, step
 }
 
 // transformFixture writes source lines to disk and returns a ready cfg + step.
@@ -39,7 +50,8 @@ func transformFixture(t *testing.T, sourceType config.StepType, sourceLines stri
 		Type:           config.TransformStepType,
 		From:           "src",
 		JQ:             program,
-		JQProgram:      mustCompile(t, program),
+		JQProgram:      mustCompile(t, program, "$parent"),
+		UsesParent:     true,
 		Limit:          limit,
 		OutputFilename: filepath.Join(dir, "tr.jsonl"),
 	}
@@ -115,4 +127,55 @@ func TestTransformStepRun_UnknownFromStepFails(t *testing.T) {
 	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
 
 	assert.ErrorContains(t, err, "ghost")
+}
+
+func TestTransformStepRun_CollectSeesAllRowsAsArray(t *testing.T) {
+	// three source rows; dedupe across rows requires seeing them all at once
+	cfg, step := collectFixture(t, config.ShellStepType,
+		`{"tags":["b","a"]}`+"\n"+`{"tags":["a","c"]}`+"\n"+`{"tags":["b"]}`+"\n",
+		`[.[].tags[]] | unique | .[]`, 0)
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{`"a"`, `"b"`, `"c"`}, readOutput(t, step.OutputFilename))
+}
+
+func TestTransformStepRun_CollectWithPromptSourceSeesResponses(t *testing.T) {
+	lines := `{"id":"1","format":"json","prompt":"p","response":{"n":2}}` + "\n" +
+		`{"id":"2","format":"json","prompt":"p","response":{"n":1}}` + "\n"
+	cfg, step := collectFixture(t, config.PromptStepType, lines, `sort_by(.n) | .[0].n`, 0)
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{`1`}, readOutput(t, step.OutputFilename))
+}
+
+func TestTransformStepRun_CollectRespectsLimit(t *testing.T) {
+	cfg, step := collectFixture(t, config.ShellStepType,
+		`{"v":1}`+"\n"+`{"v":2}`+"\n"+`{"v":3}`+"\n",
+		`.[].v`, 2)
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Len(t, readOutput(t, step.OutputFilename), 2)
+}
+
+func TestTransformStepRun_ParentVariable(t *testing.T) {
+	// fan-out questions while carrying the source chunk from lineage
+	lines := `{"id":"r1","format":"json","prompt":"p","response":{"questions":[{"q":"why?"},{"q":"how?"}]},` +
+		`"values":{".chopdoc.chunk":{"id":"c1","value":"the source chunk"}}}` + "\n"
+	cfg, step := transformFixture(t, config.PromptStepType, lines,
+		`.questions[] | {q: .q, chunk: $parent.chopdoc.chunk}`, 0)
+	step.JQProgram = mustCompile(t, step.JQ, "$parent")
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		`{"chunk":"the source chunk","q":"why?"}`,
+		`{"chunk":"the source chunk","q":"how?"}`,
+	}, readOutput(t, step.OutputFilename))
 }

--- a/step/transform_step_test.go
+++ b/step/transform_step_test.go
@@ -179,3 +179,48 @@ func TestTransformStepRun_ParentVariable(t *testing.T) {
 		`{"chunk":"the source chunk","q":"how?"}`,
 	}, readOutput(t, step.OutputFilename))
 }
+
+func TestTransformStepRun_JSONSourceFormat(t *testing.T) {
+	// pretty-printed JSON array file — unreadable line-by-line, the exact
+	// shape of downloaded API responses and HF dataset dumps
+	pretty := `[
+    {
+        "instruction": "problem one"
+    },
+    {
+        "instruction": "problem two"
+    },
+    {
+        "instruction": "problem three"
+    }
+]`
+	cfg, step := transformFixture(t, config.ShellStepType, pretty, `.[:2][]`, 0)
+	step.SourceFormat = "json"
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		`{"instruction":"problem one"}`,
+		`{"instruction":"problem two"}`,
+	}, readOutput(t, step.OutputFilename))
+}
+
+func TestTransformStepRun_JSONSourceRespectsLimit(t *testing.T) {
+	cfg, step := transformFixture(t, config.ShellStepType, `[1, 2, 3, 4]`, `.[]`, 2)
+	step.SourceFormat = "json"
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	require.NoError(t, err)
+	assert.Len(t, readOutput(t, step.OutputFilename), 2)
+}
+
+func TestTransformStepRun_JSONSourceInvalidJSONFails(t *testing.T) {
+	cfg, step := transformFixture(t, config.ShellStepType, `[1, 2,`, `.[]`, 0)
+	step.SourceFormat = "json"
+
+	err := (&TransformStep{}).Run(context.Background(), cfg, step, cfg.OutputFolder)
+
+	assert.Error(t, err)
+}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -15,6 +15,12 @@ import (
 	"github.com/mirpo/datamatic/retry"
 )
 
+// jqParentVar is the variable name per-row transform programs may declare to
+// access the source row's lineage (see jsonl.UnfoldLineage for its shape);
+// the runtime passes its value positionally, so only the compile site here
+// needs the name.
+const jqParentVar = "$parent"
+
 // setStepType determines and sets the step type based on step configuration
 func setStepType(step *config.Step) error {
 	switch step.Type {
@@ -157,7 +163,7 @@ func PreprocessConfig(cfg *config.Config) error {
 			// programs see an array of rows and must not use $parent at all
 			program, err := jq.Compile(step.JQ)
 			if err != nil && !step.Collect {
-				program, err = jq.Compile(step.JQ, jq.ParentVar)
+				program, err = jq.Compile(step.JQ, jqParentVar)
 				step.UsesParent = err == nil
 			}
 			if err != nil {

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -137,7 +137,10 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Transform steps
+		// Transform steps (collect is their field — reject it elsewhere)
+		if step.Collect && step.Type != config.TransformStepType {
+			return fmt.Errorf("step '%s': 'collect' is only valid on transform steps", step.Name)
+		}
 		if step.Type == config.TransformStepType {
 			if step.From == "" {
 				return fmt.Errorf("step '%s': 'from' is required for transform steps", step.Name)
@@ -149,7 +152,14 @@ func PreprocessConfig(cfg *config.Config) error {
 				return fmt.Errorf("step '%s': limit must be >= 0", step.Name)
 			}
 
+			// probe without variables first: success means the program never
+			// references $parent, so the runtime can skip lineage work; collect
+			// programs see an array of rows and must not use $parent at all
 			program, err := jq.Compile(step.JQ)
+			if err != nil && !step.Collect {
+				program, err = jq.Compile(step.JQ, jq.ParentVar)
+				step.UsesParent = err == nil
+			}
 			if err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
 			}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -143,13 +143,25 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Transform steps (collect is their field — reject it elsewhere)
+		// Transform steps (collect/sourceFormat are their fields — reject elsewhere)
 		if step.Collect && step.Type != config.TransformStepType {
 			return fmt.Errorf("step '%s': 'collect' is only valid on transform steps", step.Name)
+		}
+		if step.SourceFormat != "" && step.Type != config.TransformStepType {
+			return fmt.Errorf("step '%s': 'sourceFormat' is only valid on transform steps", step.Name)
 		}
 		if step.Type == config.TransformStepType {
 			if step.From == "" {
 				return fmt.Errorf("step '%s': 'from' is required for transform steps", step.Name)
+			}
+			switch step.SourceFormat {
+			case "", config.SourceFormatJSONL: // default: one row per line
+			case config.SourceFormatJSON:
+				if step.Collect {
+					return fmt.Errorf("step '%s': 'collect' has no effect with sourceFormat json — the program already runs once over the whole file", step.Name)
+				}
+			default:
+				return fmt.Errorf("step '%s': unknown sourceFormat '%s' (expected 'jsonl' or 'json')", step.Name, step.SourceFormat)
 			}
 			if err := requireEarlierStep(stepNames, "from", step.From); err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -458,3 +458,39 @@ func TestPreprocessConfig_CollectValidation(t *testing.T) {
 		assert.ErrorContains(t, PreprocessConfig(cfg), "collect")
 	})
 }
+
+func TestPreprocessConfig_SourceFormat(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "src", Run: "echo '[]' > src.json", OutputFilename: "src.json"},
+			{Name: "pick", JQ: `.[]`, From: "src", SourceFormat: "json"},
+		}
+		return cfg
+	}
+
+	t.Run("json format on transform passes", func(t *testing.T) {
+		assert.NoError(t, PreprocessConfig(base()))
+	})
+
+	t.Run("unknown format fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].SourceFormat = "yaml"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "sourceFormat")
+	})
+
+	t.Run("sourceFormat on prompt step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{
+			Name: "gen", Prompt: "p", Model: "ollama:m", Count: 1, SourceFormat: "json",
+		})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "sourceFormat")
+	})
+
+	t.Run("collect with json source fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Collect = true
+		assert.ErrorContains(t, PreprocessConfig(cfg), "collect")
+	})
+}

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -447,3 +447,14 @@ func TestPreprocessConfig_PromptPlaceholders(t *testing.T) {
 		assert.ErrorContains(t, PreprocessConfig(cfg), "both as a whole")
 	})
 }
+
+func TestPreprocessConfig_CollectValidation(t *testing.T) {
+	t.Run("collect only valid on transform steps", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 2, Collect: true},
+		}
+		assert.ErrorContains(t, PreprocessConfig(cfg), "collect")
+	})
+}


### PR DESCRIPTION
## Summary

Closes the remaining data-access gaps for transform steps. After this PR, **zero external-jq shell steps remain across all 19 examples** — no external tools between your data sources and the dataset.

### `collect: true` — fan-in

The jq program runs once over an **array of all source rows**:

```yaml
- name: unique_instructions
  from: generate_instructions
  collect: true
  jq: 'map(.instructions[]) | unique[] | {id: @base64, instruction: .}'
```

Verified **byte-identical** to the shell pipeline it replaces (`cat | jq | sort | uniq | jq`).

### `$parent` — lineage access

Per-row programs reach the source row's lineage as `$parent.step.field`:

```yaml
- name: flatten_question_chunk
  from: questions_per_chunk
  jq: '.questions[] | {question, chunk: $parent.chopdoc_by_sentence.chunk, textEvidence}'
```

- lineage keys unfold via `jsonl.UnfoldLineage` (the format's owner)
- `$parent` usage is detected at config load by a probe compile; programs that don't use it skip all lineage work at runtime
- `$parent` inside a `collect` program is a config-time compile error

### `sourceFormat: json` — whole-file JSON sources

Downloaded pretty-printed JSON arrays (API dumps, HF dataset files) are now consumable — this killed the last external jq (example 15):

```yaml
- name: math_problems_10
  from: download_dataset
  sourceFormat: json
  jq: '.[:10][]'
```

### Under the hood
- `jq.RunEach` streams results with early stop — `collect`+`limit` is O(limit) memory; `Run` is a thin wrapper
- jq named variables: `Compile(src, vars...)` / `Run(input, values...)`; the wrapper stays domain-free (no datamatic concepts in the jq package)
- `runPerRow`/`runCollect`/`runWholeJSON` are separate straight-line paths sharing `limitedEmit` and `runProgram` helpers

### Examples
- **6**: both remaining shell-jq steps migrated (join + final result via `$parent`); fixed the old copy-paste bug writing `response` into both `instruction` and `response`
- **7**: flatten (fan-out + parent chunk) and high-rating filter (parent merge) migrated
- **15**: `sourceFormat: json` replaces the last jq CLI call
- **17**: new `label_distribution` step — dataset QA (`group_by` counts) in one collect expression
- README: `collect`, `$parent`, `sourceFormat`, and single-quoting guidance for jq programs

## Verified live (local ollama)
- Example 17: 10 generated docs → distribution table (`case_study: 3, press_release: 2, …`)
- Example 7 smoke (chopdoc + deepseek-r1:1.5b): 2 chunks → 6 questions with parent chunk → 5 high-rated rows with `{question, chunk, textEvidence, rating}` merged from lineage
- Example 15 **full**: real 212MB pretty-printed `MathInstruct.json` → 10 problems → 10 llama3.2 reasoning solutions
- Collect before/after: byte-identical output vs the replaced shell pipeline

## Test plan
- [x] `go test ./...` — 13 packages green
- [x] `golangci-lint run` — 0 issues
- [x] All 19 example configs validate