### PR TITLE
feat: add validate subcommand — check a config without running it

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ datamatic -config config.yaml
 
 # With debug output
 datamatic -config config.yaml -verbose -log-pretty
+
+# Check a config without running anything (great as a CI step for
+# committed workflows): parses, preprocesses and validates — schemas,
+# cross-step references, jq programs — and exits non-zero on any error
+datamatic validate -config config.yaml
 ```
 
 **Other providers:**
@@ -223,7 +228,8 @@ With values from linked steps:
 ## CLI Reference
 
 ```bash
-datamatic [OPTIONS]
+datamatic [OPTIONS]            # run the workflow
+datamatic validate [OPTIONS]   # check the config and exit (0 = valid)
 
 Options:
   -config string

--- a/datamatic.go
+++ b/datamatic.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mirpo/datamatic/runner"
 	"github.com/mirpo/datamatic/utils"
 	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -25,6 +24,13 @@ var (
 )
 
 func main() {
+	// subcommand form: `datamatic validate -config x.yaml`
+	validateOnly := len(os.Args) > 1 && os.Args[1] == "validate"
+	args := os.Args[1:]
+	if validateOnly {
+		args = os.Args[2:]
+	}
+
 	cfg := config.NewConfig()
 
 	var ver bool
@@ -37,7 +43,7 @@ func main() {
 	flag.BoolVar(&cfg.ValidateResponse, "validate-response", cfg.ValidateResponse, "Validate JSON response from server to match the schema")
 	flag.BoolVar(&cfg.SkipCliWarning, "skip-cli-warning", cfg.SkipCliWarning, "Skip external CLI warning")
 
-	flag.Parse()
+	flag.CommandLine.Parse(args) //nolint:errcheck // flag.ExitOnError exits on failure
 
 	if ver {
 		slog.Info("datamatic", "version", version, "commit", commit)
@@ -54,37 +60,14 @@ func main() {
 		log.Fatal().Msg("Config path is required")
 	}
 
-	yamlConfig, err := os.ReadFile(cfg.ConfigFile)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Reading config file")
+	if err := utils.LoadConfigFile(cfg); err != nil {
+		log.Fatal().Err(err).Msg("Config check failed")
 	}
 
-	var tempCfg struct {
-		EnvVars []string `yaml:"envVars"`
-	}
-	err = yaml.Unmarshal(yamlConfig, &tempCfg)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Parsing config file for env vars")
-	}
-
-	expandedYaml, err := utils.ExpandEnv(string(yamlConfig), tempCfg.EnvVars)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Expanding environment variables in config file")
-	}
-
-	err = config.ParseYAML([]byte(expandedYaml), cfg)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Parsing config file")
-	}
-
-	err = utils.PreprocessConfig(cfg)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to preprocess config")
-	}
-
-	err = cfg.Validate()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to validate config file")
+	if validateOnly {
+		// command result, not a log event: stable stdout regardless of log settings
+		fmt.Printf("Config is valid: %d steps\n", len(cfg.Steps))
+		return
 	}
 
 	if commands := cfg.ShellCommands(); !cfg.SkipCliWarning && len(commands) > 0 {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -2,7 +2,6 @@ package runner_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,59 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestValidateConfigFromExamples(t *testing.T) {
-	matches, err := filepath.Glob("../examples/**/**/*.yaml")
-	assert.NoError(t, err, "Failed to glob YAML files")
-
-	assert.NotEmpty(t, matches, "No YAML files found in examples directory")
-
-	for _, path := range matches {
-		t.Logf("Testing file: %s", path)
-
-		testName := filepath.ToSlash(path)
-
-		t.Run(testName, func(t *testing.T) {
-			setupTestEnvVars(t, path)
-
-			data, err := os.ReadFile(path)
-			assert.NoError(t, err, "Failed to read file: %s", path)
-
-			expandedYaml, err := utils.ExpandEnv(string(data), nil)
-			assert.NoError(t, err, "Failed to expand env vars for file: %s", path)
-
-			var cfg config.Config
-			err = config.ParseYAML([]byte(expandedYaml), &cfg)
-			assert.NoError(t, err, "Failed to parse YAML: %s", path)
-
-			cfg.OutputFolder = "test"
-			cfg.SkipCliWarning = true
-
-			err = utils.PreprocessConfig(&cfg)
-			assert.NoError(t, err, "Preprocessing failed for file: %s", path)
-
-			err = cfg.Validate()
-			assert.NoError(t, err, "Validation failed for file: %s", path)
-		})
-	}
-}
-
-// setupTestEnvVars sets up environment variables needed for specific test configs
-func setupTestEnvVars(t *testing.T, path string) {
-	// For the workdir-multi-stage-pipeline example that uses env vars
-	if filepath.Base(filepath.Dir(path)) == "18. workdir-multi-stage-pipeline" {
-		os.Setenv("REQUIRED_FILE", "prompts.csv")
-		os.Setenv("DOWNLOAD_DIR", "downloads")
-		os.Setenv("PROVIDER", "ollama")
-		os.Setenv("MODEL", "llama3.2")
-		t.Cleanup(func() {
-			os.Unsetenv("REQUIRED_FILE")
-			os.Unsetenv("DOWNLOAD_DIR")
-			os.Unsetenv("PROVIDER")
-			os.Unsetenv("MODEL")
-		})
-	}
-}
 
 func TestRun_CancelledContextStopsExecution(t *testing.T) {
 	dir := t.TempDir()

--- a/utils/load.go
+++ b/utils/load.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mirpo/datamatic/config"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadConfigFile runs the full config pipeline for cfg.ConfigFile: read,
+// fail-fast env-var expansion, strict YAML parse, preprocessing and
+// validation. On success cfg holds the canonical, ready-to-run config.
+func LoadConfigFile(cfg *config.Config) error {
+	raw, err := os.ReadFile(cfg.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+
+	// pre-pass with a lenient decoder: only envVars is needed before expansion
+	var envOnly struct {
+		EnvVars []string `yaml:"envVars"`
+	}
+	if err := yaml.Unmarshal(raw, &envOnly); err != nil {
+		return fmt.Errorf("parsing config file for env vars: %w", err)
+	}
+
+	expanded, err := ExpandEnv(string(raw), envOnly.EnvVars)
+	if err != nil {
+		return fmt.Errorf("expanding environment variables: %w", err)
+	}
+
+	if err := config.ParseYAML([]byte(expanded), cfg); err != nil {
+		return err
+	}
+
+	if err := PreprocessConfig(cfg); err != nil {
+		return err
+	}
+
+	return cfg.Validate()
+}

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -493,4 +494,96 @@ func TestPreprocessConfig_SourceFormat(t *testing.T) {
 		cfg.Steps[1].Collect = true
 		assert.ErrorContains(t, PreprocessConfig(cfg), "collect")
 	})
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	valid := `
+version: 1.0
+steps:
+  - name: gen
+    model: ollama:m
+    prompt: hi
+    count: 2
+  - name: pick
+    from: gen
+    jq: '.'
+`
+
+	t.Run("valid config loads, preprocesses and validates", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.ConfigFile = write(t, valid)
+		cfg.OutputFolder = t.TempDir()
+
+		err := LoadConfigFile(cfg)
+
+		assert.NoError(t, err)
+		assert.Len(t, cfg.Steps, 2)
+		assert.Equal(t, config.TransformStepType, cfg.Steps[1].Type)
+		assert.NotNil(t, cfg.Steps[1].JQProgram, "preprocessing ran")
+	})
+
+	t.Run("missing declared env var fails", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.ConfigFile = write(t, "version: 1.0\nenvVars:\n  - DATAMATIC_TEST_MISSING_VAR\nsteps:\n  - name: g\n    model: ollama:m\n    prompt: p\n")
+		cfg.OutputFolder = t.TempDir()
+
+		assert.ErrorContains(t, LoadConfigFile(cfg), "DATAMATIC_TEST_MISSING_VAR")
+	})
+
+	t.Run("missing file fails", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.ConfigFile = filepath.Join(t.TempDir(), "nope.yaml")
+		cfg.OutputFolder = t.TempDir()
+
+		assert.Error(t, LoadConfigFile(cfg))
+	})
+}
+
+func TestValidateConfigFromExamples(t *testing.T) {
+	matches, err := filepath.Glob("../examples/**/**/*.yaml")
+	assert.NoError(t, err, "Failed to glob YAML files")
+
+	assert.NotEmpty(t, matches, "No YAML files found in examples directory")
+
+	for _, path := range matches {
+		t.Logf("Testing file: %s", path)
+
+		testName := filepath.ToSlash(path)
+
+		t.Run(testName, func(t *testing.T) {
+			setupTestEnvVars(t, path)
+
+			cfg := config.NewConfig()
+			cfg.ConfigFile = path
+			cfg.OutputFolder = "test"
+
+			assert.NoError(t, LoadConfigFile(cfg), "Config check failed for file: %s", path)
+		})
+	}
+}
+
+// setupTestEnvVars sets up environment variables needed for specific test configs
+func setupTestEnvVars(t *testing.T, path string) {
+	// For the workdir-multi-stage-pipeline example that uses env vars
+	if filepath.Base(filepath.Dir(path)) == "18. workdir-multi-stage-pipeline" {
+		os.Setenv("REQUIRED_FILE", "prompts.csv")
+		os.Setenv("DOWNLOAD_DIR", "downloads")
+		os.Setenv("PROVIDER", "ollama")
+		os.Setenv("MODEL", "llama3.2")
+		t.Cleanup(func() {
+			os.Unsetenv("REQUIRED_FILE")
+			os.Unsetenv("DOWNLOAD_DIR")
+			os.Unsetenv("PROVIDER")
+			os.Unsetenv("MODEL")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

```bash
datamatic validate -config workflow.yaml
# Config is valid: 3 steps
```

A one-line CI gate for committed workflows: runs the full config pipeline — strict YAML parse (typos and removed syntax are errors), env-var fail-fast, JSON-schema compilation, cross-step reference checks, `.item` rules, jq program compilation, `$parent`/`collect` rules — with **zero side effects**: no output directory, no interactive CLI warning, no LLM calls. Exits non-zero on any error; the summary goes to stdout (stable regardless of log settings).

### Under the hood
- The load pipeline (read → env expansion → strict parse → preprocess → validate) moves from `main` into `utils.LoadConfigFile`, now shared by three consumers: the run path, the validate path, and the example-config sweep test
- That sweep test (`TestValidateConfigFromExamples`) moves from `runner` to `utils` — after the dedup it no longer touched a single runner symbol
- Subcommand dispatch is 5 lines of stdlib `os.Args` handling — deliberately no CLI framework for one subcommand

## Verified live
- `validate` over all 19 example configs: 19 OK
- Broken config (self-reference): clear error, exit 1
- Missing `-config`: exit 1

## Test plan
- [x] `go test ./...` — 13 packages green (new `LoadConfigFile` table: valid pipeline, missing env var, missing file; examples sweep relocated)
- [x] `golangci-lint run` — 0 issues

CI usage:
```yaml
- run: datamatic validate -config workflow.yaml
```