### PR TITLE
feat: parallel row generation with concurrency: N

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Build multi-step AI workflows with schema-guided reasoning. Works with Ollama, L
 - **JSON Schema Validation** - Structured output with type safety (YAML-native or JSON string formats)
 - **Text Generation** - Flexible content creation
 - **Explicit Iteration** - `count: N` for generators, `forEach: step` to run once per row of an earlier step; reference the current row as `{{.item.field}}`
+- **Parallel Rows** - `concurrency: N` generates rows of a prompt step in parallel while keeping output in row order
 - **Native Template Values** - referenced values keep their JSON types: `{{range .item.companies}}`, `{{len .item.tags}}`, `{{if .item.isActive}}` all work; arrays still print as `a, b` and numbers verbatim
 - **Schema-Guided Reasoning (SGR)** - Guide LLMs through systematic analysis using structured schemas
 - **Image Analysis** - Visual model integration
@@ -124,6 +125,22 @@ datamatic validate -config config.yaml
 - OpenAI: `model: openai:gpt-4o-mini` + `export OPENAI_API_KEY=sk-...`
 - OpenRouter: `model: openrouter:meta-llama/llama-3.2-3b` + `export OPENROUTER_API_KEY=sk-...`
 - Gemini: `model: gemini:gemini-2.0-flash` + `export GEMINI_API_KEY=...`
+
+### Parallel Generation
+
+Rows of a prompt step are independent, so they can be generated in parallel:
+
+```yaml
+steps:
+  - name: analyze
+    model: openai:gpt-4o-mini
+    forEach: documents
+    concurrency: 5   # up to 5 rows generated at once (default: 1)
+```
+
+- Applies to **prompt steps only** (`count` or `forEach`); using it on transform or shell steps is a config error.
+- Output stays in row order regardless of which request finishes first, so datasets remain deterministic.
+- Raise it for cloud providers, which handle many parallel requests. Keep it low (or `1`) for a single local GPU — Ollama/LM Studio serve only a few requests at a time, so a high value won't help and may thrash.
 
 ### Transform Steps
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,8 +69,9 @@ type Step struct {
 	SourceFormat   string      `yaml:"sourceFormat"` // transform steps: "jsonl" (default, line per row) or "json" (whole file is one value)
 	WorkDir        string      `yaml:"workDir,omitempty"`
 	SystemPrompt   string      `yaml:"systemPrompt"`
-	Count          int         `yaml:"count"`   // generator steps: how many rows to produce (default 3)
-	ForEach        string      `yaml:"forEach"` // iterate once per row of an earlier step
+	Count          int         `yaml:"count"`       // generator steps: how many rows to produce (default 3)
+	ForEach        string      `yaml:"forEach"`     // iterate once per row of an earlier step
+	Concurrency    int         `yaml:"concurrency"` // prompt steps: rows to generate in parallel (default 1)
 	ModelConfig    ModelConfig `yaml:"modelConfig"`
 	OutputFilename string      `yaml:"outputFilename"`
 	JSONSchemaRaw  interface{} `yaml:"jsonSchema"`

--- a/examples/v1/10. openrouter-example/config.yaml
+++ b/examples/v1/10. openrouter-example/config.yaml
@@ -9,6 +9,8 @@ steps:
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
     count: 5
+    # cloud APIs handle many parallel requests — generate rows concurrently
+    concurrency: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -24,6 +26,7 @@ steps:
       - Occupation
       - Brief backstory (2-3 sentences)
     count: 3
+    concurrency: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/examples/v1/11. gemini-example/config.yaml
+++ b/examples/v1/11. gemini-example/config.yaml
@@ -9,6 +9,8 @@ steps:
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
     count: 5
+    # cloud APIs handle many parallel requests — generate rows concurrently
+    concurrency: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -24,6 +26,7 @@ steps:
       - Occupation
       - Brief backstory (2-3 sentences)
     count: 3
+    concurrency: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/examples/v1/18. workdir-multi-stage-pipeline/config.yaml
+++ b/examples/v1/18. workdir-multi-stage-pipeline/config.yaml
@@ -28,6 +28,9 @@ steps:
   - name: analyze_complexity
     model: $PROVIDER:$MODEL
     forEach: convert_to_jsonl
+    # rows are independent — run several in parallel (raise for cloud providers,
+    # keep low for a single local GPU)
+    concurrency: 4
     systemPrompt: |
       You are an expert in analyzing instructional prompts and assessing their complexity.
       Rate prompts based on:

--- a/examples/v1/9. openai-example/config.yaml
+++ b/examples/v1/9. openai-example/config.yaml
@@ -9,6 +9,8 @@ steps:
       Generate a unique and creative title for a science fiction story.
       The title should be intriguing and capture the reader's attention.
     count: 5
+    # cloud APIs handle many parallel requests — generate rows concurrently
+    concurrency: 5
     modelConfig:
       temperature: 0.7
       maxTokens: 100
@@ -24,6 +26,7 @@ steps:
       - Occupation
       - Brief backstory (2-3 sentences)
     count: 3
+    concurrency: 3
     modelConfig:
       temperature: 0.8
     jsonSchema:

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,6 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TV
 github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/llmtest/server.go
+++ b/internal/llmtest/server.go
@@ -12,13 +12,16 @@ import (
 )
 
 type Server struct {
-	URL   string
-	Delay time.Duration // set before first request; simulates a slow server
+	URL        string
+	Delay      time.Duration // set before first request; simulates a slow server
+	EchoPrompt bool          // when true, respond with the last user message instead of scripted content
 
 	server    *httptest.Server
 	mu        sync.Mutex
 	responses []string
 	requests  []map[string]interface{}
+	inFlight  int
+	maxInFlt  int
 }
 
 // NewServer returns a mock chat-completions server that answers with the given
@@ -28,6 +31,9 @@ func NewServer(t *testing.T, responses ...string) *Server {
 	s := &Server{responses: responses}
 
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.enter()
+		defer s.leave()
+
 		if s.Delay > 0 {
 			select {
 			case <-time.After(s.Delay):
@@ -46,7 +52,13 @@ func NewServer(t *testing.T, responses ...string) *Server {
 		if idx >= len(s.responses) {
 			idx = len(s.responses) - 1
 		}
-		content := s.responses[idx]
+		var content string
+		switch {
+		case s.EchoPrompt:
+			content = lastUserMessage(req)
+		case len(s.responses) > 0:
+			content = s.responses[idx]
+		}
 		s.mu.Unlock()
 
 		model, _ := req["model"].(string)
@@ -70,6 +82,45 @@ func NewServer(t *testing.T, responses ...string) *Server {
 
 	s.URL = s.server.URL
 	return s
+}
+
+func (s *Server) enter() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inFlight++
+	if s.inFlight > s.maxInFlt {
+		s.maxInFlt = s.inFlight
+	}
+}
+
+func (s *Server) leave() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inFlight--
+}
+
+// MaxConcurrent returns the peak number of requests handled simultaneously.
+func (s *Server) MaxConcurrent() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlt
+}
+
+// lastUserMessage returns the content of the final user message in the request,
+// used by EchoPrompt mode to make responses row-identifiable.
+func lastUserMessage(req map[string]interface{}) string {
+	messages, _ := req["messages"].([]interface{})
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg, ok := messages[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if msg["role"] == "user" {
+			content, _ := msg["content"].(string)
+			return content
+		}
+	}
+	return ""
 }
 
 func (s *Server) CallCount() int {

--- a/internal/llmtest/server_test.go
+++ b/internal/llmtest/server_test.go
@@ -3,8 +3,11 @@ package llmtest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,4 +45,35 @@ func TestServer_ScriptedResponsesAndCapture(t *testing.T) {
 	require.Len(t, srv.Requests(), 3)
 	assert.Equal(t, 0.5, srv.Requests()[0]["temperature"])
 	assert.Equal(t, "m1", resp1["model"], "echoes request model to avoid mismatch warnings")
+}
+
+func TestServer_EchoPrompt(t *testing.T) {
+	srv := NewServer(t)
+	srv.EchoPrompt = true
+
+	content := func(r map[string]interface{}) string {
+		choices := r["choices"].([]interface{})
+		msg := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+		return msg["content"].(string)
+	}
+
+	resp := post(t, srv.URL, `{"model":"m","messages":[{"role":"user","content":"hello 42"}]}`)
+	assert.Equal(t, "hello 42", content(resp), "echoes the last user message back as the response")
+}
+
+func TestServer_MaxConcurrent(t *testing.T) {
+	srv := NewServer(t, "ok")
+	srv.Delay = 30 * time.Millisecond
+
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			post(t, srv.URL, fmt.Sprintf(`{"model":"m","messages":[{"role":"user","content":"%d"}]}`, i))
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 5, srv.MaxConcurrent(), "all 5 requests overlap because of the delay")
 }

--- a/step/prompt_step.go
+++ b/step/prompt_step.go
@@ -3,6 +3,7 @@ package step
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
@@ -11,6 +12,7 @@ import (
 	"github.com/mirpo/datamatic/promptbuilder"
 	"github.com/mirpo/datamatic/retry"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
 )
 
 func newProviderConfigFromStep(step config.Step, httpTimeout int) llm.ProviderConfig {
@@ -27,6 +29,14 @@ func newProviderConfigFromStep(step config.Step, httpTimeout int) llm.ProviderCo
 
 type PromptStep struct{}
 
+// sourceRows holds every line of a referenced step's output, read once so the
+// per-row workers only do in-memory lookups instead of re-scanning the file.
+type sourceRows struct {
+	step       config.Step
+	fieldPaths []string
+	lines      []string
+}
+
 func (p *PromptStep) retryLLMGeneration(ctx context.Context, cfg *config.Config, provider llm.Provider, req llm.GenerateRequest, response **llm.GenerateResponse) error {
 	return retry.Do(ctx, cfg.RetryConfig, func() error {
 		resp, err := provider.Generate(ctx, req)
@@ -39,20 +49,13 @@ func (p *PromptStep) retryLLMGeneration(ctx context.Context, cfg *config.Config,
 }
 
 func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
-	maxResult := step.ResolvedCount
-	i := 0
-
-	// registerInvalid tracks consecutive invalid LLM responses; it returns a
-	// terminal error once the budget (retryConfig.maxAttempts) is exhausted.
-	invalidAttempts := 0
-	registerInvalid := func(cause error, responseText string) error {
-		invalidAttempts++
-		log.Warn().Err(cause).Msgf("invalid LLM response (attempt %d/%d): %s",
-			invalidAttempts, cfg.RetryConfig.MaxAttempts, responseText)
-		if invalidAttempts >= cfg.RetryConfig.MaxAttempts {
-			return fmt.Errorf("row %d: LLM returned invalid response %d times in a row: %w", i, invalidAttempts, cause)
-		}
-		return nil
+	total := step.ResolvedCount
+	// PreprocessConfig resolves the default (0 → 1); this clamp only guards
+	// direct Run calls in unit tests that bypass preprocessing, where a
+	// zero-capacity errgroup limit would deadlock.
+	workers := step.Concurrency
+	if workers < 1 {
+		workers = 1
 	}
 
 	writer, err := jsonl.NewWriter(step.OutputFilename)
@@ -66,80 +69,105 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 		return fmt.Errorf("failed to create LLM provider: %w", err)
 	}
 
-	hasSchemaSchema := step.JSONSchema.HasSchemaDefinition()
+	hasSchema := step.JSONSchema.HasSchemaDefinition()
 
-	promptBuilder, err := promptbuilder.NewPromptBuilder(step.Prompt, step.ForEach)
+	// parse the prompt once to discover which steps it references, then read
+	// each referenced file a single time up front (rows only differ by values)
+	base, err := promptbuilder.NewPromptBuilder(step.Prompt, step.ForEach)
+	if err != nil {
+		return err
+	}
+	sources, err := loadSources(base, cfg, total)
 	if err != nil {
 		return err
 	}
 
-	// resolve referenced source steps once; only row values change per iteration
-	type sourceRef struct {
-		step       config.Step
-		fieldPaths []string
-	}
-	var sources []sourceRef
-	for stepName, fieldPaths := range promptBuilder.GroupPlaceholdersByStep() {
-		refStep := cfg.GetStepByName(stepName)
-		if refStep == nil {
-			return fmt.Errorf("prompt references unknown step '%s'", stepName)
-		}
-		sources = append(sources, sourceRef{step: *refStep, fieldPaths: fieldPaths})
+	runRow := func(ctx context.Context, i int) (jsonl.LineEntity, error) {
+		return p.runRow(ctx, cfg, step, hasSchema, provider, sources, i)
 	}
 
-	for i < maxResult {
-		log.Info().
-			Str("step_name", step.Name).
-			Str("step_type", string(step.Type)).
-			Int("iteration", i).
-			Msg("Running step")
+	return generate(ctx, total, workers, writer, runRow)
+}
 
-		for _, src := range sources {
-			stepValues, err := readStepValuesBatch(src.step, outputFolder, i, src.fieldPaths)
-			if err != nil {
-				return fmt.Errorf("failed to read values from step '%s': %w", src.step.Name, err)
-			}
+// runRow produces a single output row: build its prompt from the preloaded
+// source values, call the LLM, and retry within the per-row attempt budget
+// when the response fails validation.
+func (p *PromptStep) runRow(ctx context.Context, cfg *config.Config, step config.Step, hasSchema bool, provider llm.Provider, sources []sourceRows, i int) (jsonl.LineEntity, error) {
+	log.Info().
+		Str("step_name", step.Name).
+		Str("step_type", string(step.Type)).
+		Int("iteration", i).
+		Msg("Running step")
 
-			promptBuilder.AddStepValues(src.step.Name, stepValues)
+	pb, err := promptbuilder.NewPromptBuilder(step.Prompt, step.ForEach)
+	if err != nil {
+		return jsonl.LineEntity{}, err
+	}
+
+	for _, src := range sources {
+		if i >= len(src.lines) {
+			return jsonl.LineEntity{}, fmt.Errorf("step '%s': row %d not found (only %d rows)", src.step.Name, i, len(src.lines))
 		}
-
-		userPrompt, err := promptBuilder.BuildPrompt()
+		values, err := extractStepValues(src.step, src.lines[i], src.fieldPaths)
 		if err != nil {
-			return fmt.Errorf("failed to build prompt: %w", err)
+			return jsonl.LineEntity{}, fmt.Errorf("failed to read values from step '%s' row %d: %w", src.step.Name, i, err)
+		}
+		pb.AddStepValues(src.step.Name, values)
+	}
+
+	var base64Image string
+	if step.HasImages() {
+		imagePath, err := fs.PickImageFile(step.ImagePath, i)
+		if err != nil {
+			return jsonl.LineEntity{}, fmt.Errorf("failed to find images by pattern '%s': %w", step.ImagePath, err)
 		}
 
-		var base64Image string
-		if step.HasImages() {
-			imagePath, err := fs.PickImageFile(step.ImagePath, i)
-			if err != nil {
-				return fmt.Errorf("failed to find images by pattern '%s': %w", step.ImagePath, err)
-			}
-
-			base64Image, err = fs.ImageToBase64(imagePath)
-			if err != nil {
-				return fmt.Errorf("failed to encode image '%s': %w", imagePath, err)
-			}
-
-			promptBuilder.AddValue(base64Image[:15], step.Name, "image", imagePath)
+		base64Image, err = fs.ImageToBase64(imagePath)
+		if err != nil {
+			return jsonl.LineEntity{}, fmt.Errorf("failed to encode image '%s': %w", imagePath, err)
 		}
 
+		pb.AddValue(base64Image[:15], step.Name, "image", imagePath)
+	}
+
+	userPrompt, err := pb.BuildPrompt()
+	if err != nil {
+		return jsonl.LineEntity{}, fmt.Errorf("failed to build prompt: %w", err)
+	}
+
+	req := llm.GenerateRequest{
+		UserMessage:   userPrompt,
+		SystemMessage: step.SystemPrompt,
+		IsJSON:        hasSchema,
+		JSONSchema:    step.JSONSchema,
+		Base64Image:   base64Image,
+	}
+
+	invalidAttempts := 0
+	// registerInvalid records an unusable response (schema violation or
+	// malformed line) and returns a terminal error once the attempt budget is
+	// exhausted; nil means "retry this row".
+	registerInvalid := func(cause error, responseText string) error {
+		invalidAttempts++
+		log.Warn().Err(cause).Msgf("row %d: invalid LLM response (attempt %d/%d): %s",
+			i, invalidAttempts, cfg.RetryConfig.MaxAttempts, responseText)
+		if invalidAttempts >= cfg.RetryConfig.MaxAttempts {
+			return fmt.Errorf("row %d: LLM returned invalid response %d times in a row: %w", i, invalidAttempts, cause)
+		}
+		return nil
+	}
+
+	for {
 		var response *llm.GenerateResponse
-		err = p.retryLLMGeneration(ctx, cfg, provider, llm.GenerateRequest{
-			UserMessage:   userPrompt,
-			SystemMessage: step.SystemPrompt,
-			IsJSON:        hasSchemaSchema,
-			JSONSchema:    step.JSONSchema,
-			Base64Image:   base64Image,
-		}, &response)
-		if err != nil {
-			return fmt.Errorf("failed to get response from LLM after retries: %w", err)
+		if err := p.retryLLMGeneration(ctx, cfg, provider, req, &response); err != nil {
+			return jsonl.LineEntity{}, fmt.Errorf("row %d: failed to get response from LLM after retries: %w", i, err)
 		}
 
-		if cfg.ValidateResponse && hasSchemaSchema {
+		if cfg.ValidateResponse && hasSchema {
 			log.Debug().Msg("Validating response from LLM using JSON schema")
 			if err := step.JSONSchema.ValidateJSONText(response.Text); err != nil {
 				if failErr := registerInvalid(err, response.Text); failErr != nil {
-					return failErr
+					return jsonl.LineEntity{}, failErr
 				}
 				continue
 			}
@@ -147,22 +175,109 @@ func (p *PromptStep) Run(ctx context.Context, cfg *config.Config, step config.St
 
 		log.Info().Msgf("Response from LLM: '%s'", response.Text)
 
-		lineEntity, err := jsonl.NewLineEntity(response.Text, userPrompt, hasSchemaSchema, promptBuilder.GetValues())
+		lineEntity, err := jsonl.NewLineEntity(response.Text, userPrompt, hasSchema, pb.GetValues())
 		if err != nil {
 			if failErr := registerInvalid(err, response.Text); failErr != nil {
-				return failErr
+				return jsonl.LineEntity{}, failErr
 			}
 			continue
 		}
 
-		err = writer.WriteLine(lineEntity)
-		if err != nil {
-			return fmt.Errorf("failed to write output line: %w", err)
+		return lineEntity, nil
+	}
+}
+
+// loadSources resolves the steps referenced by the prompt and reads each of
+// their output files once into memory, indexed by row.
+func loadSources(base *promptbuilder.PromptBuilder, cfg *config.Config, total int) ([]sourceRows, error) {
+	var sources []sourceRows
+	for stepName, fieldPaths := range base.GroupPlaceholdersByStep() {
+		refStep := cfg.GetStepByName(stepName)
+		if refStep == nil {
+			return nil, fmt.Errorf("prompt references unknown step '%s'", stepName)
 		}
 
-		invalidAttempts = 0
-		i++
+		lines, err := readAllLines(refStep.OutputFilename, total)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read values from step '%s': %w", stepName, err)
+		}
+
+		sources = append(sources, sourceRows{step: *refStep, fieldPaths: fieldPaths, lines: lines})
+	}
+	return sources, nil
+}
+
+// readAllLines reads up to `limit` non-empty lines from a JSONL file in a
+// single pass (limit <= 0 reads them all).
+func readAllLines(path string, limit int) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := fs.NewLineScanner(file)
+	for scanner.Scan() {
+		if limit > 0 && len(lines) >= limit {
+			break
+		}
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// generate runs rows through runRow with up to `workers` in flight and writes
+// their results to the writer in row order. A single collector goroutine keeps
+// output deterministic and streams each row as soon as its predecessors are
+// done, so a mid-run failure still leaves the completed prefix on disk.
+func generate(ctx context.Context, total, workers int, writer *jsonl.Writer, runRow func(context.Context, int) (jsonl.LineEntity, error)) error {
+	if total == 0 {
+		return nil
 	}
 
-	return nil
+	results := make([]jsonl.LineEntity, total)
+	done := make(chan int, total)
+	writeErr := make(chan error, 1)
+
+	go func() {
+		arrived := make([]bool, total)
+		next := 0
+		for i := range done {
+			arrived[i] = true
+			for next < total && arrived[next] {
+				if err := writer.WriteLine(results[next]); err != nil {
+					writeErr <- fmt.Errorf("failed to write output line: %w", err)
+					return
+				}
+				results[next] = jsonl.LineEntity{} // let the written row be GC'd
+				next++
+			}
+		}
+		writeErr <- nil
+	}()
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
+	for i := range total {
+		g.Go(func() error {
+			line, err := runRow(gctx, i)
+			if err != nil {
+				return err
+			}
+			results[i] = line
+			done <- i
+			return nil
+		})
+	}
+
+	runErr := g.Wait()
+	close(done)
+	if werr := <-writeErr; werr != nil {
+		return werr
+	}
+	return runErr
 }

--- a/step/prompt_step_test.go
+++ b/step/prompt_step_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
@@ -134,6 +135,85 @@ func TestPromptStepRun_RecoversAfterTransientInvalidResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, countLines(t, step.OutputFilename))
 	assert.Equal(t, 4, srv.CallCount()) // 1 failed + 3 good
+}
+
+func TestPromptStepRun_ConcurrencyLimitsInFlight(t *testing.T) {
+	srv := llmtest.NewServer(t, "ok")
+	srv.Delay = 40 * time.Millisecond
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+	step.ResolvedCount = 8
+	step.Concurrency = 3
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, 8, countLines(t, step.OutputFilename))
+	assert.Equal(t, 8, srv.CallCount())
+	assert.LessOrEqual(t, srv.MaxConcurrent(), 3, "never more than concurrency requests at once")
+	assert.Greater(t, srv.MaxConcurrent(), 1, "actually runs in parallel")
+}
+
+func TestPromptStepRun_OrderedOutputRegardlessOfCompletion(t *testing.T) {
+	// forEach source with recognizable rows; echo mode makes each response equal
+	// to its prompt, and the delay shuffles completion order.
+	srv := llmtest.NewServer(t)
+	srv.EchoPrompt = true
+	srv.Delay = 20 * time.Millisecond
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+
+	srcPath := filepath.Join(dir, "src.jsonl")
+	var lines string
+	for i := range 6 {
+		lines += `{"id":"r` + string(rune('0'+i)) + `","format":"text","prompt":"p","response":"item-` + string(rune('0'+i)) + `"}` + "\n"
+	}
+	require.NoError(t, os.WriteFile(srcPath, []byte(lines), 0o644))
+
+	cfg.Steps = []config.Step{
+		{Name: "src", Type: config.PromptStepType, OutputFilename: srcPath},
+	}
+	step.ForEach = "src"
+	step.ResolvedCount = 6
+	step.Concurrency = 4
+	step.Prompt = "{{.src}}"
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+	require.NoError(t, err)
+
+	for i, line := range readOutput(t, step.OutputFilename) {
+		assert.Contains(t, line, "item-"+string(rune('0'+i)),
+			"output row %d must correspond to source row %d despite parallel completion", i, i)
+	}
+}
+
+func TestPromptStepRun_ConcurrentRowFailureCancelsAndPreservesPrefix(t *testing.T) {
+	// row 3's prompt reads a field that does not exist -> that row errors;
+	// the step must fail and stop, not hang.
+	srv := llmtest.NewServer(t, `{"title":"ok"}`)
+	cfg, step, dir := promptStepConfig(t, srv.URL)
+
+	srcPath := filepath.Join(dir, "src.jsonl")
+	var lines string
+	for i := range 6 {
+		// row 3 has no "title" field, others do
+		if i == 3 {
+			lines += `{"id":"r3","format":"json","prompt":"p","response":{"other":1}}` + "\n"
+		} else {
+			lines += `{"id":"r` + string(rune('0'+i)) + `","format":"json","prompt":"p","response":{"title":"t` + string(rune('0'+i)) + `"}}` + "\n"
+		}
+	}
+	require.NoError(t, os.WriteFile(srcPath, []byte(lines), 0o644))
+
+	cfg.Steps = []config.Step{
+		{Name: "src", Type: config.PromptStepType, OutputFilename: srcPath, JSONSchema: testSchema(t, titleSchema)},
+	}
+	step.ForEach = "src"
+	step.ResolvedCount = 6
+	step.Concurrency = 2
+	step.Prompt = "use {{.src.title}}"
+
+	err := (&PromptStep{}).Run(context.Background(), cfg, step, dir)
+	require.Error(t, err, "a failing row must fail the whole step")
+	assert.Contains(t, err.Error(), "title")
 }
 
 func TestPromptStepRun_NativeTemplateRendering(t *testing.T) {

--- a/step/stepdata.go
+++ b/step/stepdata.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mirpo/datamatic/config"
-	"github.com/mirpo/datamatic/fs"
 	"github.com/mirpo/datamatic/jsonl"
 	"github.com/mirpo/datamatic/promptbuilder"
 )
@@ -52,8 +51,6 @@ func getSourceDataFromLine(step config.Step, line string) (interface{}, string, 
 	}
 }
 
-var readLineFromFile = fs.ReadLineFromFile
-
 // extractFieldByPath extracts a field from a decoded JSON row using a dot
 // path, returning the native value. An empty path means identity (the whole
 // row), matching jq's '.'.
@@ -82,16 +79,12 @@ func extractFieldByPath(data interface{}, path string) (interface{}, error) {
 	return current, nil
 }
 
-// readStepValuesBatch reads multiple field values from a step in one operation
-func readStepValuesBatch(step config.Step, outputFolder string, lineNumber int, fieldPaths []string) (map[string]promptbuilder.StepValue, error) {
-	line, err := readLineFromFile(step.OutputFilename, lineNumber)
-	if err != nil {
-		return nil, err
-	}
-
+// extractStepValues decodes a single already-read source line and pulls the
+// requested field values from it.
+func extractStepValues(step config.Step, line string, fieldPaths []string) (map[string]promptbuilder.StepValue, error) {
 	sourceData, recordID, _, err := getSourceDataFromLine(step, line)
 	if err != nil {
-		return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+		return nil, err
 	}
 
 	result := make(map[string]promptbuilder.StepValue)

--- a/step/stepdata_test.go
+++ b/step/stepdata_test.go
@@ -1,7 +1,6 @@
 package step
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mirpo/datamatic/config"
@@ -108,15 +107,13 @@ func TestGetSourceDataFromLine(t *testing.T) {
 	}
 }
 
-func TestReadStepValuesBatch(t *testing.T) {
+func TestExtractStepValues(t *testing.T) {
 	tests := []struct {
 		name       string
 		step       config.Step
 		mockLine   string
-		mockErr    error
 		fieldPaths []string
 		wantResult map[string]promptbuilder.StepValue
-		wantErr    bool
 	}{
 		{
 			name:       "Shell step - multiple fields",
@@ -149,42 +146,19 @@ func TestReadStepValuesBatch(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:       "File read error",
-			step:       config.Step{Type: config.ShellStepType},
-			mockErr:    fmt.Errorf("mocked read error"),
-			fieldPaths: []string{"name"},
-			wantErr:    true,
-		},
 	}
-
-	origRead := readLineFromFile
-	defer func() { readLineFromFile = origRead }()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			readLineFromFile = func(_ string, _ int) (string, error) {
-				return tt.mockLine, tt.mockErr
-			}
-
-			result, err := readStepValuesBatch(tt.step, "", 0, tt.fieldPaths)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
+			result, err := extractStepValues(tt.step, tt.mockLine, tt.fieldPaths)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantResult, result)
 		})
 	}
 }
 
-func TestReadStepValuesBatch_NativeValues(t *testing.T) {
-	origRead := readLineFromFile
-	defer func() { readLineFromFile = origRead }()
-	readLineFromFile = func(_ string, _ int) (string, error) {
-		return `{"id":"r1","format":"json","prompt":"p","response":{"pop":6184000,"member":false,"langs":["a","b"],"jobs":[{"name":"Acme","months":26}]}}`, nil
-	}
+func TestExtractStepValues_NativeValues(t *testing.T) {
+	line := `{"id":"r1","format":"json","prompt":"p","response":{"pop":6184000,"member":false,"langs":["a","b"],"jobs":[{"name":"Acme","months":26}]}}`
 
 	step := config.Step{Type: config.PromptStepType, JSONSchema: testSchema(t, `{
 		"type":"object",
@@ -193,7 +167,7 @@ func TestReadStepValuesBatch_NativeValues(t *testing.T) {
 		"additionalProperties":false
 	}`)}
 
-	result, err := readStepValuesBatch(step, "", 0, []string{"pop", "member", "langs", "jobs"})
+	result, err := extractStepValues(step, line, []string{"pop", "member", "langs", "jobs"})
 	require.NoError(t, err)
 
 	assert.Equal(t, promptbuilder.Number(6184000), result["pop"].Content, "numbers stay numeric")

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -352,7 +352,17 @@ func validateIterationSettings(step *config.Step, stepNames map[string]bool) err
 		if step.Count != 0 || step.ForEach != "" {
 			return fmt.Errorf("'count' and 'forEach' are only valid on prompt steps")
 		}
+		if step.Concurrency != 0 {
+			return fmt.Errorf("'concurrency' is only valid on prompt steps")
+		}
 		return nil
+	}
+
+	if step.Concurrency < 0 {
+		return fmt.Errorf("concurrency must be >= 1")
+	}
+	if step.Concurrency == 0 {
+		step.Concurrency = 1
 	}
 
 	if step.Count < 0 {

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -389,6 +389,52 @@ func TestPreprocessConfig_CountAndForEach(t *testing.T) {
 	})
 }
 
+func TestPreprocessConfig_Concurrency(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "seed", Prompt: "p", Model: "ollama:m", Count: 2},
+		}
+		return cfg
+	}
+
+	t.Run("unset concurrency defaults to 1", func(t *testing.T) {
+		cfg := base()
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, 1, cfg.Steps[0].Concurrency)
+	})
+
+	t.Run("explicit concurrency is preserved", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Concurrency = 4
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, 4, cfg.Steps[0].Concurrency)
+	})
+
+	t.Run("negative concurrency fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Concurrency = -1
+		assert.ErrorContains(t, PreprocessConfig(cfg), "concurrency")
+	})
+
+	t.Run("concurrency on transform step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{
+			Name: "t", JQ: ".", From: "seed", Concurrency: 2,
+		})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "concurrency")
+	})
+
+	t.Run("concurrency on shell step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{
+			Name: "sh", Run: "echo hi > x.jsonl", OutputFilename: "x.jsonl", Concurrency: 2,
+		})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "concurrency")
+	})
+}
+
 func TestPreprocessConfig_PromptPlaceholders(t *testing.T) {
 	base := func() *config.Config {
 		cfg := config.NewConfig()


### PR DESCRIPTION
## What

Adds `concurrency: N` to prompt steps to generate independent rows in parallel.

```yaml
steps:
  - name: analyze
    model: openai:gpt-4o-mini
    forEach: documents
    concurrency: 5   # up to 5 rows at once (default: 1)
```

- Parallel generation via `errgroup.SetLimit(N)`; a single collector goroutine writes results in **strict source-row order**, so output datasets stay deterministic regardless of which request finishes first.
- Default `1` (resolved in preprocessing). Rejected on transform/shell steps at config time — same altitude as `count`/`forEach`.
- Raise it for cloud providers; keep it low for a single local GPU (documented in README).

## Also in this PR

- **Kills O(n²) source I/O:** each referenced source file is now read once up front instead of being re-scanned from line 0 for every row.
- **Per-row retry budget:** replaces the old step-global *consecutive*-invalid counter (which had cross-row semantics that don't exist under parallelism) with a clean per-row budget.
- **Examples/docs:** cloud examples (9/10/11) and the `$PROVIDER` demo (18) set a concurrency value; README gains a "Parallel Generation" section.

## Verification

- `go test -race ./...` green (the only goroutine code in the repo).
- `golangci-lint run` — 0 issues.
- All 19 examples pass `datamatic validate`.
- Live Ollama A/B (4 rows, `llama3.2`): `concurrency: 1` = 4.87s vs `concurrency: 4` = 1.56s (**3.1×**), both producing correctly-ordered output.

New tests cover: config validation (default/negative/wrong-step-type), in-flight cap never exceeds N, output row order preserved despite shuffled completion, and mid-run row failure cancels cleanly. Mock server gained `MaxConcurrent()` and `EchoPrompt` to test parallelism and ordering.