### PR TITLE
docs: fix example README bugs and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ steps:
 
 ```bash
 # Generate data
-datamatic -config config.yaml
+datamatic --config config.yaml
 
 # With debug output
-datamatic -config config.yaml -verbose -log-pretty
+datamatic --config config.yaml --verbose --log-pretty
 
 # Check a config without running anything (great as a CI step for
 # committed workflows): parses, preprocesses and validates — schemas,
 # cross-step references, jq programs — and exits non-zero on any error
-datamatic validate -config config.yaml
+datamatic validate --config config.yaml
 ```
 
 **Other providers:**
@@ -183,7 +183,7 @@ steps:
 ```
 
 ```bash
-PROVIDER=ollama MODEL=llama3.2 datamatic -config config.yaml
+PROVIDER=ollama MODEL=llama3.2 datamatic --config config.yaml
 ```
 
 Variables listed in `envVars` are validated before execution (fail-fast). See [Multi-Stage Pipeline example](./examples/v1/18.%20workdir-multi-stage-pipeline/README.md) for more details.

--- a/examples/v1/10. openrouter-example/README.md
+++ b/examples/v1/10. openrouter-example/README.md
@@ -13,4 +13,7 @@ Install:
 
 ## Run dataset generation
 
-`export OPENROUTER_API_KEY=sk-or-v1-XXXX datamatic --config ./config.yaml --verbose`
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-XXXX
+datamatic --config ./config.yaml --verbose
+```

--- a/examples/v1/11. gemini-example/README.md
+++ b/examples/v1/11. gemini-example/README.md
@@ -11,4 +11,7 @@ Install:
 
 ## Run dataset generation
 
-`export GEMINI_API_KEY=XXXX datamatic --config ./config.yaml --verbose`
+```bash
+export GEMINI_API_KEY=XXXX
+datamatic --config ./config.yaml --verbose
+```

--- a/examples/v1/13. retry configuration example/README.md
+++ b/examples/v1/13. retry configuration example/README.md
@@ -6,6 +6,10 @@ This example demonstrates how to configure retry logic in datamatic for handling
 
 Retry configuration allows datamatic to automatically retry failed API calls with intelligent backoff strategies. This is especially useful when:
 
+- The provider is rate-limiting requests (429) during large runs
+- A local server (Ollama/LM Studio) is briefly overloaded or still loading a model
+- Transient network timeouts or 5xx errors interrupt a long generation
+
 ## Configuration Parameters
 
 ### `retryConfig` Section
@@ -19,6 +23,8 @@ Retry configuration allows datamatic to automatically retry failed API calls wit
 | `backoffMultiplier` | `2.0`   | Exponential backoff multiplier                    |
 
 ### Retry Strategy
+
+Failed attempts wait `initialDelay`, then grow the delay by `backoffMultiplier` after each retry (exponential backoff), capped at `maxDelay`, up to `maxAttempts` total attempts.
 
 ### Error Types
 

--- a/examples/v1/15. simple math reasoning/README.md
+++ b/examples/v1/15. simple math reasoning/README.md
@@ -11,7 +11,6 @@ Install:
 - [Ollama](https://ollama.com/download)
 - Install model: `ollama pull llama3.2`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
-- [jq](https://github.com/jqlang/jq)
 
 ## Run dataset generation
 

--- a/examples/v1/17. document classification with schema-guided reasoning/README.md
+++ b/examples/v1/17. document classification with schema-guided reasoning/README.md
@@ -18,9 +18,9 @@ The schema acts as a reasoning framework that guides the LLM through systematic 
 
 ```python
 class DocumentClassification(BaseModel):
-  document_type: Literal["invoice", "contract", "receipt", ...]
+  document_type: Literal["receipt", "blog_post", "article", "news", "invoice", ...]
   brief_summary: str
-  key_entities_mentioned: List[Literal["payment", "risk", "regulator", ...]]
+  key_entities_mentioned: List[str]
   keywords: List[str] = Field(..., description="Up to 10 keywords")
 ```
 
@@ -33,16 +33,15 @@ Install:
 - `datamatic`
 - [Ollama](https://ollama.com/download)
 - Install model: `ollama pull llama3.2`
-- [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 
 ## Example Output
 
 ```json
 {
-  "document_type": "contract",
-  "brief_summary": "Service agreement between vendor and customer for cloud infrastructure services",
-  "key_entities_mentioned": ["vendor", "customer", "service", "legal", "financial"],
-  "keywords": ["cloud", "infrastructure", "SLA", "agreement", "services", "pricing", "terms", "liability"]
+  "document_type": "invoice",
+  "brief_summary": "Invoice from a cloud provider billing a customer for monthly infrastructure usage",
+  "key_entities_mentioned": ["vendor", "customer", "invoice number", "amount due", "billing period"],
+  "keywords": ["invoice", "cloud", "billing", "infrastructure", "payment", "due date", "services"]
 }
 ```
 

--- a/examples/v1/19. transform step and fan-out/README.md
+++ b/examples/v1/19. transform step and fan-out/README.md
@@ -18,4 +18,4 @@ Install:
 
 ## Run dataset generation
 
-`datamatic -config ./config.yaml -verbose`
+`datamatic --config ./config.yaml --verbose`

--- a/examples/v1/4. using huggingface and jq cli/config.yaml
+++ b/examples/v1/4. using huggingface and jq cli/config.yaml
@@ -2,6 +2,7 @@ version: 1.0
 
 steps:
   - name: download_dataset
+    type: shell
     run: hf download --repo-type dataset flytech/python-codes-25k --local-dir ./ --include python-codes-25k.jsonl
     outputFilename: python-codes-25k.jsonl
 

--- a/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/README.md
+++ b/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/README.md
@@ -1,6 +1,6 @@
 # Complex dataset using DuckDb and LM studio
 
-Example shows how to download parquet dataset from Huggingface, convert to Parquet to JSONL using DuckDb, take top 100 and analyze the problem using LM Studio.
+Example shows how to download a parquet dataset from Huggingface, convert Parquet to JSONL using DuckDB, take the top 100 rows and analyze the problem using LM Studio.
 
 ## Requirements
 
@@ -8,7 +8,6 @@ Install:
 
 - `datamatic`
 - [LM Studio](https://lmstudio.ai/download)
-- Install model: `ollama pull llama3.2`
 - Open LM Studio, find and download `hermes-3-llama-3.2-3b`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 - [DuckDB](https://duckdb.org/docs/installation/)

--- a/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/config.yaml
+++ b/examples/v1/5. using duckdb to convert parquet huggingface dataset and lmstudio/config.yaml
@@ -8,8 +8,8 @@ steps:
 
   - name: convert_to_jsonl
     type: shell
-    run: duckdb -c "COPY (SELECT * FROM read_parquet('./data/test-00000-of-00001.parquet')) TO 'output.json' (FORMAT JSON);"
-    outputFilename: output.json
+    run: duckdb -c "COPY (SELECT * FROM read_parquet('./data/test-00000-of-00001.parquet')) TO 'output.jsonl' (FORMAT JSON);"
+    outputFilename: output.jsonl
 
   - name: synthetic_math
     from: convert_to_jsonl

--- a/examples/v1/7. fine-tuning dataset/README.md
+++ b/examples/v1/7. fine-tuning dataset/README.md
@@ -1,6 +1,6 @@
-# Multi step git commands dataset using Ollama
+# Fine-tuning Q&A dataset from a document (RAG-style) using Ollama
 
-Example shows dataset generation of git commands in natural language using Ollama.
+Example builds a fine-tuning dataset from a source document: it downloads an essay, splits it into chunks, generates cognitive-level (Bloom's taxonomy) questions with supporting text evidence per chunk, then validates and rates each question and keeps only the high-quality ones.
 
 ## Requirements
 

--- a/examples/v1/8. hugginface images and qwen2.5vl or gemma3/README.md
+++ b/examples/v1/8. hugginface images and qwen2.5vl or gemma3/README.md
@@ -1,6 +1,6 @@
 # Using vision model
 
-Example shows complex dataset generation using dataset from Huggingface and Gemma3 visual model using Ollama
+Example shows complex dataset generation using a dataset from Huggingface and a vision model (Qwen2.5-VL or Gemma 3) via Ollama or LM Studio
 
 ## Requirements
 
@@ -14,7 +14,6 @@ Install:
     - `gemma3:4b`
 - [magick](https://imagemagick.org/script/download.php) (to convert dataset images from BMP => JPEG)
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
-- [jq](https://github.com/jqlang/jq)
 
 ## Run dataset generation
 

--- a/examples/v1/9. openai-example/README.md
+++ b/examples/v1/9. openai-example/README.md
@@ -11,4 +11,7 @@ Install:
 
 ## Run dataset generation
 
-`export OPENAI_API_KEY=sk-XXXXX datamatic --config ./config.yaml --verbose`
+```bash
+export OPENAI_API_KEY=sk-XXXXX
+datamatic --config ./config.yaml --verbose
+```


### PR DESCRIPTION
## Part 1 (Block A) — cheap cleanup of the examples showcase

Highest-ROI, zero-risk polish. **Docs/config only — no engine changes.** All configs still pass \`datamatic validate\`.

### Broken run commands (didn't run at all)
- **9 / 10 / 11** — \`export KEY=... datamatic --config ...\` on one line makes \`datamatic\` an argument to \`export\`, so it never runs. Split into an export line + a datamatic line.

### Wrong / misleading docs
- **7** — titled "git commands dataset" (copy-paste from #6) but it's document Q&A; retitled + accurate description of the RAG-style pipeline.
- **5** — removed stray \`ollama pull llama3.2\` requirement (it uses LM Studio) + fixed a typo.

### Spurious dependencies (contradicted our "jq is built-in" message)
- **8** — removed \`jq\`; also fixed model wording (Qwen2.5-VL / Gemma 3).
- **15** — removed \`jq\`.
- **17** — removed \`hf\` (no download step).

### Flag consistency
- Normalized all docs to double-dash \`--config\`/\`--verbose\` (root README + example 19). Both forms work in Go's \`flag\` package — this is purely cosmetic consistency.

### Misc
- **13** — filled empty README section stubs.
- **17** — aligned the Python snippet and sample output with the actual schema enum (was \`"contract"\`, not in the enum).
- **4** — made the shell step's \`type: shell\` explicit.
- **5** (config) — renamed \`output.json\` → \`output.jsonl\` to match the step name and its JSONL content.

Part of the examples/reach review; Block B+C (prune 19→~10, feature matrix, trim prompts) comes next.