### PR TITLE
examples: switch local model llama3.2 → qwen3:1.7b

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,5 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ollama pull qwen3:1.7b
-          # for simplicity, we set count == 1
-          sed -i -e 's/count: 10/count: 1/g' ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml
-          ./datamatic --config ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml --verbose
-          cat ./dataset/text_about_country.jsonl | jq
+          ./datamatic --config ci/smoke.yaml --verbose
+          cat ./dataset/describe.jsonl | jq

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run datamatic with ollama
         if: runner.os == 'Linux'
         run: |
-          ollama pull llama3.2
+          ollama pull qwen3:1.7b
           # for simplicity, we set count == 1
           sed -i -e 's/count: 10/count: 1/g' ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml
           ./datamatic --config ./examples/v1/3.\ complex\ json,\ linked\ steps/config.yaml --verbose

--- a/ci/smoke.yaml
+++ b/ci/smoke.yaml
@@ -1,0 +1,37 @@
+version: 1.0
+
+# Minimal CI smoke test (not a showcase example).
+# Exercises the core data flow end-to-end against a real Ollama model in
+# ~3 LLM calls: structured output -> transform fan-out -> forEach linking.
+# Small counts are baked in, so CI needs no sed/count hacks.
+steps:
+  # 1. structured output: one topic with exactly three tags
+  - name: seed
+    model: ollama:qwen3:1.7b
+    count: 1
+    prompt: |
+      Pick one programming topic and list exactly three short tags for it. Return as JSON.
+    jsonSchema:
+      type: object
+      properties:
+        topic: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+          minItems: 3
+          maxItems: 3
+      required: [topic, tags]
+      additionalProperties: false
+
+  # 2. transform fan-out: 1 seed row -> N tag rows (zero LLM cost, instant)
+  - name: tags
+    from: seed
+    jq: '.tags[] | {tag: .}'
+    limit: 2
+
+  # 3. forEach over the transform output, referencing the current row
+  - name: describe
+    model: ollama:qwen3:1.7b
+    forEach: tags
+    prompt: |
+      In one short sentence, describe the programming tag "{{.item.tag}}".

--- a/examples/v1/1. simple text generation, not linked steps/README.md
+++ b/examples/v1/1. simple text generation, not linked steps/README.md
@@ -9,7 +9,7 @@ Install:
 - `datamatic`
 - [Ollama](https://ollama.com/download)
 - [LM Studio](https://lmstudio.ai/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - Open LM Studio, find and download `hermes-3-llama-3.2-3b`
 
 ## Run dataset generation

--- a/examples/v1/1. simple text generation, not linked steps/config.yaml
+++ b/examples/v1/1. simple text generation, not linked steps/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 steps:
   - name: generate_titles_simple_ollama
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Generate a catchy and one unique news title. Come up with a wildly different and surprising news headline. Return only one news title per request, without any extra thinking.
 

--- a/examples/v1/12. cv-processing-pipeline/README.md
+++ b/examples/v1/12. cv-processing-pipeline/README.md
@@ -8,7 +8,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run dataset generation
 

--- a/examples/v1/12. cv-processing-pipeline/config.yaml
+++ b/examples/v1/12. cv-processing-pipeline/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 steps:
   - name: generate_cv
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Generate a detailed CV for a Senior Software Engineer with 8-10 years experience.
 
@@ -27,7 +27,7 @@ steps:
       maxTokens: 3000
 
   - name: extract_companies
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: generate_cv
     prompt: |
       Extract all employment information from this CV. Focus on companies, roles, and dates.
@@ -93,7 +93,7 @@ steps:
       temperature: 0.1
 
   - name: extract_courses
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: generate_cv
     prompt: |
       Extract all education and certification information from this CV.
@@ -147,7 +147,7 @@ steps:
   # native template values: iterate the extracted companies array directly —
   # one summary per CV, no transform step needed
   - name: career_summary
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: extract_companies
     modelConfig:
       temperature: 0.4

--- a/examples/v1/13. retry configuration example/README.md
+++ b/examples/v1/13. retry configuration example/README.md
@@ -68,7 +68,7 @@ retryConfig:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run Example
 

--- a/examples/v1/13. retry configuration example/config.yaml
+++ b/examples/v1/13. retry configuration example/config.yaml
@@ -8,7 +8,7 @@ retryConfig:
 
 steps:
   - name: generate_with_retry
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Generate a creative short story title about time travel.
       Make it intriguing and unique. Return only the title.

--- a/examples/v1/14. recipe generation with nested fields/README.md
+++ b/examples/v1/14. recipe generation with nested fields/README.md
@@ -45,7 +45,7 @@ details:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run Example
 

--- a/examples/v1/14. recipe generation with nested fields/config.yaml
+++ b/examples/v1/14. recipe generation with nested fields/config.yaml
@@ -1,7 +1,7 @@
 version: 1.0
 steps:
   - name: recipe_data
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     count: 5
     modelConfig:
       temperature: 0.8
@@ -109,7 +109,7 @@ steps:
         - details
 
   - name: cooking_guide
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: recipe_data
     modelConfig:
       temperature: 0.7

--- a/examples/v1/15. simple math reasoning/README.md
+++ b/examples/v1/15. simple math reasoning/README.md
@@ -9,7 +9,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 
 ## Run dataset generation

--- a/examples/v1/15. simple math reasoning/config.yaml
+++ b/examples/v1/15. simple math reasoning/config.yaml
@@ -16,7 +16,7 @@ steps:
 
   - name: solve_with_reasoning
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: math_problems_10
     modelConfig:
       temperature: 0.7

--- a/examples/v1/16. sql reasoning with checklist/README.md
+++ b/examples/v1/16. sql reasoning with checklist/README.md
@@ -19,7 +19,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 - [DuckDB CLI](https://duckdb.org/docs/installation/)
 

--- a/examples/v1/16. sql reasoning with checklist/config.yaml
+++ b/examples/v1/16. sql reasoning with checklist/config.yaml
@@ -15,7 +15,7 @@ steps:
 
   - name: generate_sql_with_reasoning
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: convert_to_jsonl
     modelConfig:
       temperature: 0.3

--- a/examples/v1/17. document classification with schema-guided reasoning/README.md
+++ b/examples/v1/17. document classification with schema-guided reasoning/README.md
@@ -32,7 +32,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Example Output
 

--- a/examples/v1/17. document classification with schema-guided reasoning/config.yaml
+++ b/examples/v1/17. document classification with schema-guided reasoning/config.yaml
@@ -3,7 +3,7 @@ version: 1.0
 steps:
   - name: generate_documents
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     count: 10
     modelConfig:
       temperature: 0.9
@@ -34,7 +34,7 @@ steps:
 
   - name: classify_documents
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: generate_documents
     modelConfig:
       temperature: 0.3

--- a/examples/v1/18. workdir-multi-stage-pipeline/README.md
+++ b/examples/v1/18. workdir-multi-stage-pipeline/README.md
@@ -10,7 +10,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 - [DuckDB](https://duckdb.org/docs/installation/)
 
@@ -127,6 +127,6 @@ Process existing directories:
 REQUIRED_FILE=prompts.csv \
 DOWNLOAD_DIR=downloads \
 PROVIDER=ollama \
-MODEL=llama3.2 \
+MODEL=qwen3:1.7b \
   datamatic --config ./config.yaml --verbose
 ```

--- a/examples/v1/19. transform step and fan-out/README.md
+++ b/examples/v1/19. transform step and fan-out/README.md
@@ -14,7 +14,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run dataset generation
 

--- a/examples/v1/19. transform step and fan-out/config.yaml
+++ b/examples/v1/19. transform step and fan-out/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 steps:
   - name: team_roster
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     count: 3
     modelConfig:
       temperature: 0.9
@@ -34,7 +34,7 @@ steps:
     jq: '.members[]'
 
   - name: bio
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: members
     prompt: |
       Write a two-sentence bio for {{.item.name}}, who works as {{.item.role}}.

--- a/examples/v1/2. simple json generation, not linked steps/README.md
+++ b/examples/v1/2. simple json generation, not linked steps/README.md
@@ -9,7 +9,7 @@ Install:
 - `datamatic`
 - [Ollama](https://ollama.com/download)
 - [LM Studio](https://lmstudio.ai/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - Open LM Studio, find and download `hermes-3-llama-3.2-3b`
 
 ## Run dataset generation

--- a/examples/v1/2. simple json generation, not linked steps/config.yaml
+++ b/examples/v1/2. simple json generation, not linked steps/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 steps:
   - name: generate_titles_json_ollama
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Generate a catchy and one unique news title. Come up with a wildly different and surprising news headline. Return only one news title per request, without any extra thinking.
     jsonSchema:

--- a/examples/v1/3. complex json, linked steps/README.md
+++ b/examples/v1/3. complex json, linked steps/README.md
@@ -8,7 +8,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run dataset generation
 

--- a/examples/v1/3. complex json, linked steps/config.yaml
+++ b/examples/v1/3. complex json, linked steps/config.yaml
@@ -1,7 +1,7 @@
 version: 1.0
 steps:
   - name: about_country
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     count: 10
     modelConfig:
       temperature: 0.9
@@ -51,7 +51,7 @@ steps:
         - independenceYear
 
   - name: text_about_country
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: about_country
     modelConfig:
       temperature: 0.9

--- a/examples/v1/4. using huggingface and jq cli/README.md
+++ b/examples/v1/4. using huggingface and jq cli/README.md
@@ -8,7 +8,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 - [hf](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)
 
 ## Run dataset generation

--- a/examples/v1/4. using huggingface and jq cli/config.yaml
+++ b/examples/v1/4. using huggingface and jq cli/config.yaml
@@ -13,7 +13,7 @@ steps:
 
   - name: explain_code
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: pick_first_20
     systemPrompt: |
       You are an expert software engineer and code analyst with deep understanding of algorithms, data structures, and software design patterns. Your task is to analyze code and explain its logic in clear, precise terms. Focus on:
@@ -41,7 +41,7 @@ steps:
 
   - name: unit_test
     type: prompt
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     forEach: explain_code
     systemPrompt: |
       You are an expert software engineer and test automation specialist. Your task is to generate comprehensive, accurate unit tests based on provided code descriptions and code snippets. Follow these instructions:

--- a/examples/v1/6. git dataset/README.md
+++ b/examples/v1/6. git dataset/README.md
@@ -10,7 +10,7 @@ Install:
 
 - `datamatic`
 - [Ollama](https://ollama.com/download)
-- Install model: `ollama pull llama3.2`
+- Install model: `ollama pull qwen3:1.7b`
 
 ## Run dataset generation
 

--- a/examples/v1/6. git dataset/config.yaml
+++ b/examples/v1/6. git dataset/config.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 steps:
   - name: generate_subtopics
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       I am building a dataset of Git-related questions and commands. List exactly 30 distinct subtopics that comprehensively cover core and advanced Git usage. Do not number the subtopics. Separate them only with commas, with no additional text or formatting.
       Each subtopic should be a short phrase, and they should be relevant to Git commands, concepts, or workflows. The subtopics should be diverse and cover various aspects of Git, including but not limited to version control, branching, merging, rebasing, conflict resolution, and collaboration.
@@ -26,7 +26,7 @@ steps:
     jq: '.subtopics | unique | .[] | {id: (. | @base64), topic: .}'
 
   - name: generate_instructions
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Generate list of 100 concise user instructions about the following Git topic: {{.split_into_unique_subtopics.topic}}.
       These instructions list will be used to train an AI assistant.
@@ -57,7 +57,7 @@ steps:
     jq: 'map(.instructions[]) | unique[] | {id: @base64, instruction: .}'
 
   - name: generate_answer
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     prompt: |
       Given the user instruction related to Git below, generate a clear, accurate, and concise response.
 
@@ -75,7 +75,7 @@ steps:
     jq: '{instruction: $parent.split_into_unique_instructions.instruction, response: .}' 
 
   - name: rate
-    model: ollama:llama3.2
+    model: ollama:qwen3:1.7b
     systemPrompt: |
       You are an expert evaluator specializing in Git documentation and instruction assessment. Your task is to analyze instruction-response pairs related to Git usage and provide numerical scores across five key dimensions. Each evaluation should be thorough, consistent, and based on clear criteria.
       Evaluation Criteria


### PR DESCRIPTION
## Modernize the default local model for Ollama-based examples

Swaps `ollama:llama3.2` → `ollama:qwen3:1.7b` across all local examples (configs + README \`ollama pull\` lines). Docs/config only — **no engine changes**.

### Why
llama3.2 (late 2024) is aging. qwen3:1.7b is newer, smaller on disk (1.4GB vs 2.0GB) and follows structured-output schemas more reliably — and this showcase is largely about schema-guided structured output.

### Chosen empirically (local bake-off)
Ran the schema-heaviest cases on each candidate with `--validate-response`:

| Model | disk | nested recipe schema | enum + 2-step classify | `<think>` leak |
|---|---|---|---|---|
| llama3.2 | 2.0GB | ✅ valid, 1 retry | ✅ valid, 0 retries | n/a |
| **qwen3:1.7b** | **1.4GB** | ✅ valid, **0 retries** | ✅ valid, **0 retries** | none |
| qwen3:0.6b | 0.5GB | ❌ fails (3 invalid in a row) | ✅ valid | none |

Plus live runs of the **real** configs: example 3 (linked steps + native template values) and example 19 (transform fan-out: 2 rosters → 7 members → 7 bios) — both clean, 0 retries.

### Notes
- **No `/no_think` plumbing needed:** Ollama's OpenAI-compatible endpoint doesn't emit `<think>` into content, so prompts are unchanged.
- **qwen3:0.6b rejected** — too weak for nested schemas, would make the showcase flaky.
- **Trade-off:** qwen3:1.7b is somewhat slower per generation than llama3.2 on the same hardware; reliability of structured output was prioritized over raw speed.

### Left unchanged
Example 5 (LM Studio hermes), 7 (deepseek-r1:1.5b reasoning), 8 (qwen2.5vl vision), 9/10/11 (cloud), and the `$PROVIDER:$MODEL` templating in 18 (only its example command updated).

Follow-up: Block B+C (prune 19→~10 examples, feature matrix, collapse cloud clones, trim giant systemPrompts) is a separate PR.