### PR TITLE
chore: remove the interactive external-CLI warning and its flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,6 @@ Options:
         Enable pretty logging, JSON when false (default true)
   -output string
         Output folder path (default "dataset")
-  -skip-cli-warning
-        Skip external CLI warning
   -validate-response
         Validate JSON response from server to match the schema (default true)
   -verbose

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,6 @@ func NewConfig() *Config {
 		OutputFolder:     "dataset",
 		HTTPTimeout:      300,
 		ValidateResponse: true,
-		SkipCliWarning:   false,
 		RetryConfig:      retry.NewDefaultConfig(),
 	}
 }
@@ -35,7 +34,6 @@ type Config struct {
 	OutputFolder     string
 	HTTPTimeout      int
 	ValidateResponse bool
-	SkipCliWarning   bool
 	Version          string       `yaml:"version"`
 	EnvVars          []string     `yaml:"envVars"`
 	Steps            []Step       `yaml:"steps"`

--- a/config/validate.go
+++ b/config/validate.go
@@ -118,15 +118,3 @@ func (c *Config) Validate() error {
 
 	return nil
 }
-
-// ShellCommands returns the run commands of all shell steps, used by the CLI
-// to warn the user before executing external applications.
-func (c *Config) ShellCommands() []string {
-	var commands []string
-	for _, step := range c.Steps {
-		if step.Type == ShellStepType {
-			commands = append(commands, step.Run)
-		}
-	}
-	return commands
-}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -202,9 +202,8 @@ func TestCLIFilenameValidation_PostPreprocessing(t *testing.T) {
 
 	t.Run("Shell step without filename in command warns but passes", func(t *testing.T) {
 		cfg := &Config{
-			Version:        "1.0",
-			RetryConfig:    retry.NewDefaultConfig(),
-			SkipCliWarning: true,
+			Version:     "1.0",
+			RetryConfig: retry.NewDefaultConfig(),
 			Steps: []Step{
 				{
 					Name:           "download_only",

--- a/datamatic.go
+++ b/datamatic.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/goforj/godump"
@@ -41,7 +40,6 @@ func main() {
 	flag.StringVar(&cfg.OutputFolder, "output", cfg.OutputFolder, "Output folder path")
 	flag.IntVar(&cfg.HTTPTimeout, "http-timeout", cfg.HTTPTimeout, "HTTP timeout: 0 - no timeout, if number - recommended to put high on poor hardware")
 	flag.BoolVar(&cfg.ValidateResponse, "validate-response", cfg.ValidateResponse, "Validate JSON response from server to match the schema")
-	flag.BoolVar(&cfg.SkipCliWarning, "skip-cli-warning", cfg.SkipCliWarning, "Skip external CLI warning")
 
 	flag.CommandLine.Parse(args) //nolint:errcheck // flag.ExitOnError exits on failure
 
@@ -68,11 +66,6 @@ func main() {
 		// command result, not a log event: stable stdout regardless of log settings
 		fmt.Printf("Config is valid: %d steps\n", len(cfg.Steps))
 		return
-	}
-
-	if commands := cfg.ShellCommands(); !cfg.SkipCliWarning && len(commands) > 0 {
-		fmt.Fprintf(os.Stderr, "⚠️ WARNING: External application call detected! The author assumes no responsibility for execution results. Please verify all external calls before proceeding. Use at your own risk.\n\nCalls: \n- %s\n\nPress Enter to continue", strings.Join(commands, "\n- "))
-		fmt.Scanln() //nolint:golint,errcheck
 	}
 
 	if cfg.Verbose {


### PR DESCRIPTION
## Remove the blocking shell-step warning

Configs with `shell` steps printed a warning and then **blocked on `fmt.Scanln` ("Press Enter to continue")**. That hangs in any non-interactive context — CI, cron, backgrounded runs — and only "worked" in CI by accident of stdin EOF. It's at odds with the commit-a-YAML-and-run-it-anywhere model, and the warning's safety value is low (you're running a config you committed).

Removed entirely:
- the warning message + the `Scanln` prompt
- the `--skip-cli-warning` flag
- the `SkipCliWarning` config field
- the now-unused `Config.ShellCommands()` helper
- the flag's mention in the README options list

Configs with shell steps now just run. `go build`, `go test ./...`, and `golangci-lint` are clean.