### PR TITLE
feat: verify a shell step created its declared outputFilename

### DIFF
--- a/step/shell_step.go
+++ b/step/shell_step.go
@@ -22,5 +22,12 @@ func (p *ShellStep) Run(ctx context.Context, cfg *config.Config, step config.Ste
 	if err := executor.ExecuteCommand(ctx, step.Run, step.WorkDir, defaultCmdTimeout); err != nil {
 		return fmt.Errorf("failed to execute external application: %w", err)
 	}
+
+	// the run command is opaque, so verify it actually produced the declared
+	// output — otherwise a typo silently breaks later steps that read this file
+	if _, err := os.Stat(step.OutputFilename); err != nil {
+		return fmt.Errorf("step '%s': command finished but its declared outputFilename '%s' was not created — make sure the run command writes exactly this file: %w",
+			step.Name, step.OutputFilename, err)
+	}
 	return nil
 }

--- a/step/shell_step_test.go
+++ b/step/shell_step_test.go
@@ -1,0 +1,56 @@
+package step
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func shellStep(t *testing.T, run string) (config.Step, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return config.Step{
+		Name:           "gen",
+		Type:           config.ShellStepType,
+		Run:            run,
+		WorkDir:        dir,
+		OutputFilename: filepath.Join(dir, "out.jsonl"),
+	}, dir
+}
+
+func TestShellStepRun_PassesWhenOutputCreated(t *testing.T) {
+	step, dir := shellStep(t, "echo hi > out.jsonl")
+
+	err := (&ShellStep{}).Run(context.Background(), config.NewConfig(), step, dir)
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(step.OutputFilename)
+	assert.NoError(t, statErr, "the declared output file exists")
+}
+
+func TestShellStepRun_FailsWhenOutputNotCreated(t *testing.T) {
+	// the command succeeds but never writes the declared outputFilename
+	// (e.g. a typo in the run command) — the step must fail, not silently pass
+	step, dir := shellStep(t, "echo hi")
+
+	err := (&ShellStep{}).Run(context.Background(), config.NewConfig(), step, dir)
+
+	require.Error(t, err, "must not silently pass when the output file is missing")
+	assert.Contains(t, err.Error(), "gen", "error names the step")
+	assert.Contains(t, err.Error(), "out.jsonl", "error names the missing file")
+}
+
+func TestShellStepRun_FailsWhenCommandWritesDifferentFile(t *testing.T) {
+	// typo: command writes out.json but the step declared out.jsonl
+	step, dir := shellStep(t, "echo hi > out.json")
+
+	err := (&ShellStep{}).Run(context.Background(), config.NewConfig(), step, dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out.jsonl")
+}


### PR DESCRIPTION
## Fail fast when a shell step's output is missing

A shell step's `run` command is opaque — datamatic can't know what file it writes, so `outputFilename` is a manual declaration that later steps read by. If `run` and `outputFilename` drift (a typo in either), the pipeline used to break **silently, downstream**.

Now: after the command finishes, `os.Stat` the declared `outputFilename` and fail fast with a clear, step-local error if it wasn't created:

```
step 'chunk_document': command finished but its declared outputFilename
'.../pg_essay.jsonl' was not created — make sure the run command writes exactly this file
```

### TDD
- ✅ passes when the command creates the file
- ✅ fails (naming the step + file) when the command creates nothing
- ✅ fails when the command writes a *different* filename (typo)

### Notes
- Shell `OutputFilename` resolves to `workDir/<name>` verbatim (no `.jsonl` forcing), so the check is exact.
- A declared **directory** (e.g. vision's `unzip -d data` target) also satisfies `os.Stat`.
- Complements the existing config-time substring heuristic (which `datamatic validate` uses before any execution); this is the runtime ground truth.
- No example configs affected — every shell step already creates its declared output.