### PR TITLE
feat: add `read:` file source — process local files as rows (D.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ See [`examples/v1/`](./examples/v1/) for the full feature matrix. Start with `ba
 ### Data integration & infrastructure
 | Example | Features shown | Backend |
 | --- | --- | --- |
+| [process-my-files](./examples/v1/process-my-files/README.md) | `read` local files (glob/dir/CSV/JSONL) into rows | Ollama |
 | [external-data](./examples/v1/external-data/README.md) | HuggingFace download + transform + shell tools | Ollama |
 | [env-and-workdir](./examples/v1/env-and-workdir/README.md) | env vars, `workDir`, `$PROVIDER`, DuckDB | Ollama |
 | [vision](./examples/v1/vision/README.md) | image → structured output (`imagePath`) | Ollama, LM Studio |

--- a/config/config.go
+++ b/config/config.go
@@ -46,12 +46,19 @@ const (
 	PromptStepType    StepType = "prompt"
 	ShellStepType     StepType = "shell"
 	TransformStepType StepType = "transform"
+	ReadStepType      StepType = "read"
 	UnknownStepType   StepType = "unknown"
 )
 
 const (
 	SourceFormatJSONL = "jsonl" // one JSON value per line (default)
 	SourceFormatJSON  = "json"  // the whole file is a single JSON value
+)
+
+const (
+	ReadFormatFiles = "files" // one row per file: {path, name, content}
+	ReadFormatCSV   = "csv"   // one row per record; columns become fields
+	ReadFormatJSONL = "jsonl" // one row per line (parsed JSON)
 )
 
 type Step struct {
@@ -61,6 +68,8 @@ type Step struct {
 	Prompt         string      `yaml:"prompt"`
 	Run            string      `yaml:"run"`
 	JQ             string      `yaml:"jq"`           // transform steps: jq program
+	Read           string      `yaml:"read"`         // read steps: file/glob/dir to load as rows
+	Format         string      `yaml:"format"`       // read steps: "files" | "csv" | "jsonl" (default: by extension)
 	From           string      `yaml:"from"`         // transform steps: source step name
 	Limit          int         `yaml:"limit"`        // transform steps: cap output rows (0 = no cap)
 	Collect        bool        `yaml:"collect"`      // transform steps: jq sees an array of ALL source rows (fan-in)

--- a/examples/v1/README.md
+++ b/examples/v1/README.md
@@ -5,6 +5,7 @@ Each folder is a self-contained `config.yaml` + `README.md`. New to datamatic? R
 | Example | Features shown | Backend |
 | --- | --- | --- |
 | [basics](./basics) | text generation, JSON schema | Ollama |
+| [process-my-files](./process-my-files) | `read` your own local files (glob/dir/CSV/JSONL) → rows | Ollama |
 | [linked-steps](./linked-steps) | step chaining, native template values (`if`/`range`/`len`) | Ollama |
 | [structured-extraction](./structured-extraction) | nested schema, both schema formats (YAML / JSON-string), native templates | Ollama |
 | [dataset-pipeline](./dataset-pipeline) | transform fan-out, fan-in (`collect`, `$parent`), rating pipeline | Ollama |

--- a/examples/v1/process-my-files/README.md
+++ b/examples/v1/process-my-files/README.md
@@ -1,0 +1,27 @@
+# Process my files
+
+Run an LLM over your **own local files** — no download, no shell step. `read`
+turns a glob/directory/`.csv`/`.jsonl` into rows; here each `.md` support ticket
+becomes a row, and each is triaged into a structured record.
+
+**Features:** `read` · `forEach` · `jsonSchema`
+
+## Steps
+
+1. `tickets` — `read: ./docs/*.md` → one row per file: `{path, name, content}`
+2. `triage` — `forEach` ticket → `{category, priority, summary}`
+
+Point `read` at your own path to process your data. Other forms:
+`read: ./data.csv` (one row per record), `read: ./seed.jsonl` (one row per line),
+`read: ./docs/` (a whole directory). Override detection with `format:`.
+
+## Requirements
+
+- `datamatic`
+- [Ollama](https://ollama.com/download) + `ollama pull qwen3:1.7b`
+
+## Run
+
+```bash
+datamatic --config ./config.yaml --verbose
+```

--- a/examples/v1/process-my-files/config.yaml
+++ b/examples/v1/process-my-files/config.yaml
@@ -1,0 +1,32 @@
+version: 1.0
+
+# Process your OWN local files — no download, no shell. Point `read` at a glob,
+# a directory, a .csv, or a .jsonl and it becomes rows; here: one row per file.
+steps:
+  - name: tickets
+    read: ./docs/*.md
+
+  - name: triage
+    model: ollama:qwen3:1.7b
+    forEach: tickets
+    modelConfig:
+      temperature: 0.2
+    prompt: |
+      Triage this support ticket. Return as JSON.
+
+      {{.item.content}}
+    jsonSchema:
+      type: object
+      properties:
+        category:
+          type: string
+          enum: [billing, bug, feature_request, account, other]
+        priority:
+          type: string
+          enum: [low, medium, high]
+        summary:
+          type: string
+          minLength: 10
+          maxLength: 200
+      required: [category, priority, summary]
+      additionalProperties: false

--- a/examples/v1/process-my-files/docs/ticket-001.md
+++ b/examples/v1/process-my-files/docs/ticket-001.md
@@ -1,0 +1,7 @@
+# Ticket 001
+
+Subject: Charged twice this month
+
+Hi, I was billed $29 twice on my April statement for the Pro plan. I only have
+one subscription. Can you refund the duplicate charge? My account email is
+jane@example.com.

--- a/examples/v1/process-my-files/docs/ticket-002.md
+++ b/examples/v1/process-my-files/docs/ticket-002.md
@@ -1,0 +1,7 @@
+# Ticket 002
+
+Subject: Export button does nothing
+
+When I click "Export to CSV" on the reports page, nothing happens — no download,
+no error. Tried Chrome and Firefox. It worked last week. This is blocking my
+monthly report.

--- a/examples/v1/process-my-files/docs/ticket-003.md
+++ b/examples/v1/process-my-files/docs/ticket-003.md
@@ -1,0 +1,7 @@
+# Ticket 003
+
+Subject: Please add dark mode
+
+Love the product! It would be great to have a dark theme for the dashboard —
+staring at the bright screen late at night is hard on the eyes. Not urgent,
+just a nice-to-have.

--- a/fs/read.go
+++ b/fs/read.go
@@ -1,0 +1,90 @@
+package fs
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// GlobFiles expands a glob pattern or a directory into a sorted list of regular
+// files (directories excluded). Results are always sorted ascending so runs are
+// deterministic. An empty match is an error.
+func GlobFiles(pattern string) ([]string, error) {
+	var candidates []string
+
+	if info, err := os.Stat(pattern); err == nil && info.IsDir() {
+		entries, err := os.ReadDir(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read directory '%s': %w", pattern, err)
+		}
+		for _, e := range entries {
+			candidates = append(candidates, filepath.Join(pattern, e.Name()))
+		}
+	} else {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob '%s': %w", pattern, err)
+		}
+		candidates = matches
+	}
+
+	files := candidates[:0]
+	for _, path := range candidates {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat '%s': %w", path, err)
+		}
+		if info.Mode().IsRegular() {
+			files = append(files, path)
+		}
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files matched '%s'", pattern)
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+// ReadTextFile returns a file's base name and its full text content.
+func ReadTextFile(path string) (string, string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read '%s': %w", path, err)
+	}
+	return filepath.Base(path), string(data), nil
+}
+
+// ReadCSV parses a CSV file into one map per record, keyed by the header row.
+func ReadCSV(path string) ([]map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open '%s': %w", path, err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CSV '%s': %w", path, err)
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	header := records[0]
+	rows := make([]map[string]string, 0, len(records)-1)
+	for _, record := range records[1:] {
+		row := make(map[string]string, len(header))
+		for i, col := range header {
+			if i < len(record) {
+				row[col] = record[i]
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}

--- a/fs/read.go
+++ b/fs/read.go
@@ -30,7 +30,7 @@ func GlobFiles(pattern string) ([]string, error) {
 		candidates = matches
 	}
 
-	files := candidates[:0]
+	var files []string
 	for _, path := range candidates {
 		info, err := os.Stat(path)
 		if err != nil {

--- a/fs/read_test.go
+++ b/fs/read_test.go
@@ -1,0 +1,75 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobFiles_SortsAndExcludesDirs(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"c.md", "a.md", "b.md"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644))
+	}
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+
+	got, err := GlobFiles(filepath.Join(dir, "*.md"))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join(dir, "a.md"),
+		filepath.Join(dir, "b.md"),
+		filepath.Join(dir, "c.md"),
+	}, got, "sorted ascending, directories excluded")
+}
+
+func TestGlobFiles_Directory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("y"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+
+	got, err := GlobFiles(dir) // a directory, not a glob
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join(dir, "a.txt"),
+		filepath.Join(dir, "b.txt"),
+	}, got)
+}
+
+func TestGlobFiles_EmptyMatchErrors(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GlobFiles(filepath.Join(dir, "*.md"))
+	require.Error(t, err)
+}
+
+func TestReadTextFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte("hello world"), 0o644))
+
+	name, content, err := ReadTextFile(p)
+
+	require.NoError(t, err)
+	assert.Equal(t, "doc.md", name)
+	assert.Equal(t, "hello world", content)
+}
+
+func TestReadCSV(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "leads.csv")
+	require.NoError(t, os.WriteFile(p, []byte("company,website\nAcme,acme.com\nGlobex,globex.io\n"), 0o644))
+
+	rows, err := ReadCSV(p)
+
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "Acme", rows[0]["company"])
+	assert.Equal(t, "acme.com", rows[0]["website"])
+	assert.Equal(t, "Globex", rows[1]["company"])
+	assert.Equal(t, "globex.io", rows[1]["website"])
+}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -2,7 +2,9 @@ package runner_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mirpo/datamatic/config"
@@ -83,4 +85,57 @@ func TestRun_TransformPipelineEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, lines, "2 of 3 seed rows survive the filter")
 	assert.Equal(t, 5, srv.CallCount(), "3 seed generations + 2 describe calls")
+}
+
+func TestRun_ReadFilesPipelineEndToEnd(t *testing.T) {
+	// read a folder of files -> prompt per file; the mock returns one response
+	// per file, and the prompt must see each file's content
+	srv := llmtest.NewServer(t)
+	srv.EchoPrompt = true
+
+	fileDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fileDir, "a.md"), []byte("alpha-content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fileDir, "b.md"), []byte("beta-content"), 0o644))
+
+	dir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.OutputFolder = dir
+	cfg.Version = "1.0"
+	cfg.Steps = []config.Step{
+		{
+			Name: "docs",
+			Read: filepath.Join(fileDir, "*.md"),
+		},
+		{
+			Name:        "summarize",
+			Model:       "ollama:test-model",
+			ForEach:     "docs",
+			Prompt:      "Summarize: {{.item.content}}",
+			ModelConfig: config.ModelConfig{BaseURL: srv.URL},
+		},
+	}
+
+	require.NoError(t, utils.PreprocessConfig(cfg))
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, runner.NewRunner(cfg).Run(context.Background()))
+
+	out := readOutputLines(t, cfg.Steps[1].OutputFilename)
+	require.Len(t, out, 2, "one row per file")
+	// echo mode: response == prompt, so content flowed through in sorted order
+	assert.Contains(t, out[0], "alpha-content")
+	assert.Contains(t, out[1], "beta-content")
+	assert.Equal(t, 2, srv.CallCount())
+}
+
+func readOutputLines(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var lines []string
+	for _, l := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if l != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
 }

--- a/step/read_step.go
+++ b/step/read_step.go
@@ -1,0 +1,102 @@
+package step
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/mirpo/datamatic/fs"
+	"github.com/mirpo/datamatic/jsonl"
+	"github.com/rs/zerolog/log"
+)
+
+type ReadStep struct{}
+
+// Run loads local files into JSONL rows: one row per file (files), per record
+// (csv), or per line (jsonl). The read path resolves relative to the current
+// working directory; rows materialize to OutputFilename like a transform step.
+func (p *ReadStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
+	files, err := fs.GlobFiles(step.Read)
+	if err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
+	}
+
+	writer, err := jsonl.NewWriter(step.OutputFilename)
+	if err != nil {
+		return fmt.Errorf("failed to create JSONL writer: %w", err)
+	}
+	defer writer.Close()
+
+	written := 0
+	for _, path := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		switch step.Format {
+		case config.ReadFormatFiles:
+			name, content, err := fs.ReadTextFile(path)
+			if err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			if err := writer.WriteJSON(map[string]interface{}{"path": path, "name": name, "content": content}); err != nil {
+				return err
+			}
+			written++
+
+		case config.ReadFormatCSV:
+			rows, err := fs.ReadCSV(path)
+			if err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			for _, row := range rows {
+				if err := writer.WriteJSON(row); err != nil {
+					return err
+				}
+				written++
+			}
+
+		case config.ReadFormatJSONL:
+			n, err := emitJSONLines(path, writer)
+			if err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			written += n
+
+		default:
+			return fmt.Errorf("step '%s': unknown read format '%s'", step.Name, step.Format)
+		}
+	}
+
+	log.Info().Msgf("read produced %d rows from %d file(s)", written, len(files))
+	return nil
+}
+
+// emitJSONLines re-emits each JSON line of a file as an output row (validating
+// that each line is well-formed JSON).
+func emitJSONLines(path string, writer *jsonl.Writer) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open '%s': %w", path, err)
+	}
+	defer f.Close()
+
+	written := 0
+	scanner := fs.NewLineScanner(f)
+	for lineNo := 0; scanner.Scan(); lineNo++ {
+		var value interface{}
+		if err := json.Unmarshal([]byte(scanner.Text()), &value); err != nil {
+			return written, fmt.Errorf("%s line %d: invalid JSON: %w", path, lineNo, err)
+		}
+		if err := writer.WriteJSON(value); err != nil {
+			return written, err
+		}
+		written++
+	}
+	if err := scanner.Err(); err != nil {
+		return written, fmt.Errorf("failed to read '%s': %w", path, err)
+	}
+	return written, nil
+}

--- a/step/read_step.go
+++ b/step/read_step.go
@@ -30,43 +30,45 @@ func (p *ReadStep) Run(ctx context.Context, cfg *config.Config, step config.Step
 	defer writer.Close()
 
 	written := 0
+	emit := limitedEmit(writer, 0, &written) // read has no limit; reuses the transform writer
+
+	// resolve the per-file loader once — the format is constant for the step
+	var loadFile func(path string) error
+	switch step.Format {
+	case config.ReadFormatFiles:
+		loadFile = func(path string) error {
+			name, content, err := fs.ReadTextFile(path)
+			if err != nil {
+				return err
+			}
+			_, err = emit(map[string]interface{}{"path": path, "name": name, "content": content})
+			return err
+		}
+	case config.ReadFormatCSV:
+		loadFile = func(path string) error {
+			rows, err := fs.ReadCSV(path)
+			if err != nil {
+				return err
+			}
+			for _, row := range rows {
+				if _, err := emit(row); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	case config.ReadFormatJSONL:
+		loadFile = func(path string) error { return emitJSONLines(path, emit) }
+	default:
+		return fmt.Errorf("step '%s': unknown read format '%s'", step.Name, step.Format)
+	}
+
 	for _, path := range files {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-
-		switch step.Format {
-		case config.ReadFormatFiles:
-			name, content, err := fs.ReadTextFile(path)
-			if err != nil {
-				return fmt.Errorf("step '%s': %w", step.Name, err)
-			}
-			if err := writer.WriteJSON(map[string]interface{}{"path": path, "name": name, "content": content}); err != nil {
-				return err
-			}
-			written++
-
-		case config.ReadFormatCSV:
-			rows, err := fs.ReadCSV(path)
-			if err != nil {
-				return fmt.Errorf("step '%s': %w", step.Name, err)
-			}
-			for _, row := range rows {
-				if err := writer.WriteJSON(row); err != nil {
-					return err
-				}
-				written++
-			}
-
-		case config.ReadFormatJSONL:
-			n, err := emitJSONLines(path, writer)
-			if err != nil {
-				return fmt.Errorf("step '%s': %w", step.Name, err)
-			}
-			written += n
-
-		default:
-			return fmt.Errorf("step '%s': unknown read format '%s'", step.Name, step.Format)
+		if err := loadFile(path); err != nil {
+			return fmt.Errorf("step '%s': %w", step.Name, err)
 		}
 	}
 
@@ -74,29 +76,27 @@ func (p *ReadStep) Run(ctx context.Context, cfg *config.Config, step config.Step
 	return nil
 }
 
-// emitJSONLines re-emits each JSON line of a file as an output row (validating
+// emitJSONLines emits each JSON line of a file as an output row (validating
 // that each line is well-formed JSON).
-func emitJSONLines(path string, writer *jsonl.Writer) (int, error) {
+func emitJSONLines(path string, emit func(interface{}) (bool, error)) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open '%s': %w", path, err)
+		return fmt.Errorf("failed to open '%s': %w", path, err)
 	}
 	defer f.Close()
 
-	written := 0
 	scanner := fs.NewLineScanner(f)
 	for lineNo := 0; scanner.Scan(); lineNo++ {
 		var value interface{}
 		if err := json.Unmarshal([]byte(scanner.Text()), &value); err != nil {
-			return written, fmt.Errorf("%s line %d: invalid JSON: %w", path, lineNo, err)
+			return fmt.Errorf("%s line %d: invalid JSON: %w", path, lineNo, err)
 		}
-		if err := writer.WriteJSON(value); err != nil {
-			return written, err
+		if _, err := emit(value); err != nil {
+			return err
 		}
-		written++
 	}
 	if err := scanner.Err(); err != nil {
-		return written, fmt.Errorf("failed to read '%s': %w", path, err)
+		return fmt.Errorf("failed to read '%s': %w", path, err)
 	}
-	return written, nil
+	return nil
 }

--- a/step/read_step_test.go
+++ b/step/read_step_test.go
@@ -1,0 +1,76 @@
+package step
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runReadStep(t *testing.T, read, format string, files map[string]string) []string {
+	t.Helper()
+	src := t.TempDir()
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(src, name), []byte(content), 0o644))
+	}
+	out := t.TempDir()
+	step := config.Step{
+		Name:           "src",
+		Type:           config.ReadStepType,
+		Read:           filepath.Join(src, read),
+		Format:         format,
+		OutputFilename: filepath.Join(out, "src.jsonl"),
+	}
+	err := (&ReadStep{}).Run(context.Background(), config.NewConfig(), step, out)
+	require.NoError(t, err)
+	return readOutput(t, step.OutputFilename)
+}
+
+func TestReadStepRun_Files(t *testing.T) {
+	lines := runReadStep(t, "*.md", config.ReadFormatFiles, map[string]string{
+		"b.md": "beta",
+		"a.md": "alpha",
+	})
+	require.Len(t, lines, 2)
+	// sorted ascending: a before b
+	assert.Contains(t, lines[0], `"name":"a.md"`)
+	assert.Contains(t, lines[0], "alpha")
+	assert.Contains(t, lines[1], `"name":"b.md"`)
+	assert.Contains(t, lines[1], "beta")
+}
+
+func TestReadStepRun_CSV(t *testing.T) {
+	lines := runReadStep(t, "leads.csv", config.ReadFormatCSV, map[string]string{
+		"leads.csv": "company,city\nAcme,NYC\nGlobex,LA\n",
+	})
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], `"company":"Acme"`)
+	assert.Contains(t, lines[0], `"city":"NYC"`)
+	assert.Contains(t, lines[1], `"company":"Globex"`)
+}
+
+func TestReadStepRun_JSONL(t *testing.T) {
+	lines := runReadStep(t, "seed.jsonl", config.ReadFormatJSONL, map[string]string{
+		"seed.jsonl": `{"x":1}` + "\n" + `{"x":2}` + "\n",
+	})
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], `"x":1`)
+	assert.Contains(t, lines[1], `"x":2`)
+}
+
+func TestReadStepRun_EmptyGlobFails(t *testing.T) {
+	out := t.TempDir()
+	step := config.Step{
+		Name:           "src",
+		Type:           config.ReadStepType,
+		Read:           filepath.Join(t.TempDir(), "*.md"),
+		Format:         config.ReadFormatFiles,
+		OutputFilename: filepath.Join(out, "src.jsonl"),
+	}
+	err := (&ReadStep{}).Run(context.Background(), config.NewConfig(), step, out)
+	require.Error(t, err)
+}

--- a/step/step.go
+++ b/step/step.go
@@ -19,6 +19,8 @@ func NewStepRunner(step config.Step) (StepRunner, error) {
 		return &ShellStep{}, nil
 	case config.TransformStepType:
 		return &TransformStep{}, nil
+	case config.ReadStepType:
+		return &ReadStep{}, nil
 	default:
 		return nil, errors.New("unsupported step type")
 	}

--- a/step/stepdata.go
+++ b/step/stepdata.go
@@ -39,10 +39,11 @@ func getSourceDataFromLine(step config.Step, line string) (interface{}, string, 
 		}
 		return decoded.Response, decoded.ID, decoded.Values, nil
 
-	case config.TransformStepType:
+	case config.TransformStepType, config.ReadStepType:
+		// both materialize plain JSON values per line (no LineEntity envelope)
 		var decoded interface{}
 		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
-			return nil, "", nil, fmt.Errorf("transform step: failed to parse JSON: %w", err)
+			return nil, "", nil, fmt.Errorf("%s step: failed to parse JSON: %w", step.Type, err)
 		}
 		return decoded, "", nil, nil
 

--- a/step/stepdata.go
+++ b/step/stepdata.go
@@ -22,7 +22,7 @@ func uuidFromString(input string) string {
 // Shell steps: full line is an unknown JSON, no lineage.
 // Prompt steps: line is a datamatic LineEntity — data is the response;
 // lineage values come back as-is (unfold them lazily via jsonl.UnfoldLineage).
-// Transform steps: full line is a raw JSON value, no lineage.
+// Transform and read steps: full line is a raw JSON value, no lineage.
 func getSourceDataFromLine(step config.Step, line string) (interface{}, string, map[string]promptbuilder.ValueShort, error) {
 	switch step.Type {
 	case config.ShellStepType:

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -24,9 +24,9 @@ const jqParentVar = "$parent"
 // setStepType determines and sets the step type based on step configuration
 func setStepType(step *config.Step) error {
 	switch step.Type {
-	case "", config.PromptStepType, config.ShellStepType, config.TransformStepType:
+	case "", config.PromptStepType, config.ShellStepType, config.TransformStepType, config.ReadStepType:
 	default:
-		return fmt.Errorf("unknown step type '%s' (expected 'prompt', 'shell' or 'transform')", step.Type)
+		return fmt.Errorf("unknown step type '%s' (expected 'prompt', 'shell', 'transform' or 'read')", step.Type)
 	}
 
 	var inferred config.StepType
@@ -41,8 +41,11 @@ func setStepType(step *config.Step) error {
 	if step.JQ != "" {
 		inferred, sourceField, count = config.TransformStepType, "jq", count+1
 	}
+	if step.Read != "" {
+		inferred, sourceField, count = config.ReadStepType, "read", count+1
+	}
 	if count != 1 {
-		return errors.New("exactly one of 'prompt', 'run' or 'jq' must be defined")
+		return errors.New("exactly one of 'prompt', 'run', 'jq' or 'read' must be defined")
 	}
 
 	if step.Type != "" && step.Type != inferred {
@@ -188,6 +191,22 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
+		// Read steps: local-file source (path resolves relative to CWD; rows
+		// materialize to outputFolder like a transform)
+		if step.Type == config.ReadStepType {
+			if step.ImagePath != "" {
+				return fmt.Errorf("step '%s': 'imagePath' is not valid on read steps", step.Name)
+			}
+			format, err := resolveReadFormat(step)
+			if err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			step.Format = format
+			if err := setOutputFilename(step, cfg.OutputFolder); err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+		}
+
 		// Normalize image path if needed
 		if step.HasImages() {
 			if err := setImagePath(step, cfg.OutputFolder); err != nil {
@@ -313,6 +332,28 @@ func getFullOutputPath(step config.Step, outputFolder string) (string, error) {
 	fullPath := filepath.Join(outputFolder, filename)
 
 	return filepath.Clean(fullPath), nil
+}
+
+// resolveReadFormat validates an explicit read `format` or infers it from the
+// path's extension (.csv/.tsv → csv, .jsonl → jsonl, otherwise files).
+func resolveReadFormat(step *config.Step) (string, error) {
+	if step.Format != "" {
+		switch step.Format {
+		case config.ReadFormatFiles, config.ReadFormatCSV, config.ReadFormatJSONL:
+			return step.Format, nil
+		default:
+			return "", fmt.Errorf("unknown format '%s' (expected 'files', 'csv' or 'jsonl')", step.Format)
+		}
+	}
+
+	switch strings.ToLower(filepath.Ext(step.Read)) {
+	case ".csv", ".tsv":
+		return config.ReadFormatCSV, nil
+	case ".jsonl":
+		return config.ReadFormatJSONL, nil
+	default:
+		return config.ReadFormatFiles, nil
+	}
 }
 
 // setOutputFilename sets the full output path for a step

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -163,7 +163,7 @@ func TestPreprocessConfig_Failures(t *testing.T) {
 			&config.Config{OutputFolder: "/tmp", Steps: []config.Step{
 				{Name: "bad", Prompt: "p", Run: "c"},
 			}},
-			"exactly one of 'prompt', 'run' or 'jq' must be defined",
+			"exactly one of 'prompt', 'run', 'jq' or 'read' must be defined",
 		},
 		{
 			"Missing provider colon",
@@ -591,5 +591,49 @@ steps:
 		cfg.OutputFolder = t.TempDir()
 
 		assert.Error(t, LoadConfigFile(cfg))
+	})
+}
+
+func TestPreprocessConfig_ReadStep(t *testing.T) {
+	base := func(read, format string) *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{{Name: "src", Read: read, Format: format}}
+		return cfg
+	}
+
+	t.Run("infers read type and files format", func(t *testing.T) {
+		cfg := base("./docs/*.md", "")
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.ReadStepType, cfg.Steps[0].Type)
+		assert.Equal(t, config.ReadFormatFiles, cfg.Steps[0].Format)
+	})
+	t.Run("infers csv from extension", func(t *testing.T) {
+		cfg := base("./leads.csv", "")
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.ReadFormatCSV, cfg.Steps[0].Format)
+	})
+	t.Run("infers jsonl from extension", func(t *testing.T) {
+		cfg := base("./seed.jsonl", "")
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.ReadFormatJSONL, cfg.Steps[0].Format)
+	})
+	t.Run("explicit format overrides extension", func(t *testing.T) {
+		cfg := base("./data.txt", config.ReadFormatCSV)
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.ReadFormatCSV, cfg.Steps[0].Format)
+	})
+	t.Run("unknown format fails", func(t *testing.T) {
+		assert.ErrorContains(t, PreprocessConfig(base("./x", "parquet")), "unknown format")
+	})
+	t.Run("read plus count fails", func(t *testing.T) {
+		cfg := base("./x/*.md", "")
+		cfg.Steps[0].Count = 3
+		assert.ErrorContains(t, PreprocessConfig(cfg), "only valid on prompt")
+	})
+	t.Run("read plus imagePath fails", func(t *testing.T) {
+		cfg := base("./x/*.md", "")
+		cfg.Steps[0].ImagePath = "*.jpg"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "imagePath")
 	})
 }


### PR DESCRIPTION
## `read:` — run a workflow over your own local files

The headline of Block D (file-in): a native `read:` step that turns local files into rows, so you can process your **own** data with no shell/download costume.

```yaml
- name: tickets
  read: ./docs/*.md          # one row per file: {path, name, content}
- name: triage
  forEach: tickets
  prompt: "Triage: {{.item.content}}"
```

### Formats (by extension, overridable with `format:`)
| Input | Rows |
|---|---|
| glob / directory / `.txt` / `.md` | one row per file: `{path, name, content}` |
| `.csv` / `.tsv` | one row per record; columns → fields |
| `.jsonl` | one row per line (parsed JSON) |

### Design
- `read:` is a new **inferred step type** (like `prompt`/`run`/`jq`).
- Read path resolves relative to **CWD** (your files); rows **materialize to `outputFolder`** like a transform, so `from:`/`forEach:` consume them unchanged.
- Glob results **always sorted** (deterministic); empty match is an error.

### Unlocked (the n8n-lite bridge)
Triage a folder of documents, enrich a CSV, extract from your `.md`/`.txt`, re-process an existing `.jsonl` — batch LLM over your own data.

### Tests (TDD)
- `fs` helpers (glob+sort+dir, CSV, text) — pure, golden
- `ReadStep.Run` — files / csv / jsonl / empty-glob
- step-type inference + preprocess validation (format inference, rejects `read`+`count`/`imagePath`)
- runner **e2e**: read a folder → `forEach` → one row per file
- New example **process-my-files** (read tickets → triage), **live-verified on qwen3:1.7b** (3 files → correct billing/bug/feature classification, 0 retries)

Full suite + `golangci-lint` clean. **Additive** — shell + DuckDB stays the tool for parquet/complex sources.

**Follow-ups (next PR):** Phase 2 — unify the image glob into `read:` + an `image:` attach field on prompt steps (removes `imagePath`); and review/simplify the complex `getSourceDataFromLine` source-reading path.