### PR TITLE
feat: write file output, config-relative paths, SGR routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,41 @@ Always wrap jq programs in single quotes: unquoted YAML silently truncates at `#
 
 jq programs are validated when the config loads. Transform steps run instantly, produce regular JSONL, and don't trigger the external-CLI warning. See the [dataset-pipeline example](./examples/v1/dataset-pipeline/README.md), which uses fan-out and fan-in.
 
+### Local Files: `read` and `write`
+
+Process your own data end to end — no shell glue:
+
+```yaml
+steps:
+  - name: leads
+    read: ./leads.csv          # local files → rows
+  - name: classified
+    forEach: leads
+    prompt: Classify {{.item.company}}
+    jsonSchema: { ... }
+  - name: report
+    from: classified
+    write: ./enriched.csv       # rows → a deliverable file
+```
+
+- **`read:`** turns local files into rows. Format is inferred from the path (overridable with `format:`):
+  - a glob / directory / `.txt` / `.md` → one row per file: `{path, name, content}`
+  - `.csv` / `.tsv` → one row per record (columns become fields)
+  - `.jsonl` → one row per line
+- **`write:`** exports a step's rows to a file, format inferred from the extension: `.csv`, `.json` (array), `.md` (table), or `.jsonl`. It's terminal and doesn't change the intermediate JSONL that other steps read.
+- **`image:`** on a prompt step attaches a file as a vision image, e.g. `image: "{{.item.path}}"` after `read`-ing a folder of images.
+- Relative `read`/`write` paths resolve **relative to the config file's directory** (so a workflow's data travels with it and runs from any working directory); absolute paths are used as-is. See the [csv-enrichment](./examples/v1/csv-enrichment/README.md) and [process-my-files](./examples/v1/process-my-files/README.md) examples.
+
+### Schema-Guided Reasoning (SGR)
+
+Shape the JSON schema to steer *how* the model reasons, not just what it returns. Three patterns ([background](https://abdullin.com/schema-guided-reasoning/)):
+
+- **Cascade** — put reasoning before the conclusion (a `reasoning` field, or a `steps[]` array, ahead of the answer). The workhorse; works well even on small local models. See [sgr-reasoning](./examples/v1/sgr-reasoning/README.md), [document-classification](./examples/v1/document-classification/README.md), [inbox-triage](./examples/v1/inbox-triage/README.md).
+- **Routing** — a discriminated union (`anyOf` of object branches, each with a `const` discriminator) makes the model pick one branch and fill only its fields; datamatic validates the union and every branch for strict output. Branch-choice accuracy needs a capable model — small local models (≤3B) reliably mis-route, so use a cloud model for real routing.
+- **Cycle** — an `array` of a repeated sub-schema (optionally bounded with `minItems`/`maxItems`) emits N reasoning items. Bounds are honored by Ollama's grammar but rejected by OpenAI strict mode.
+
+Prompt steps send the schema as strict structured output (all properties required, `additionalProperties: false`); `datamatic validate` flags schemas that break those rules before you hit the API.
+
 ### Environment Variables
 
 Configure your pipelines dynamically using `$VAR` syntax:
@@ -288,6 +323,7 @@ See [`examples/v1/`](./examples/v1/) for the full feature matrix. Start with `ba
 | Example | Features shown | Backend |
 | --- | --- | --- |
 | [process-my-files](./examples/v1/process-my-files/README.md) | `read` local files (glob/dir/CSV/JSONL) into rows | Ollama |
+| [csv-enrichment](./examples/v1/csv-enrichment/README.md) | `read` CSV → LLM enrich → `write` CSV (full office loop) | Ollama |
 | [external-data](./examples/v1/external-data/README.md) | HuggingFace download + transform + shell tools | Ollama |
 | [env-and-workdir](./examples/v1/env-and-workdir/README.md) | env vars, `workDir`, `$PROVIDER`, DuckDB | Ollama |
 | [vision](./examples/v1/vision/README.md) | image → structured output (`imagePath`) | Ollama, LM Studio |

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ const (
 	ShellStepType     StepType = "shell"
 	TransformStepType StepType = "transform"
 	ReadStepType      StepType = "read"
+	WriteStepType     StepType = "write"
 	UnknownStepType   StepType = "unknown"
 )
 
@@ -61,6 +62,13 @@ const (
 	ReadFormatJSONL = "jsonl" // one row per line (parsed JSON)
 )
 
+const (
+	WriteFormatCSV      = "csv"   // one record per row; keys become columns
+	WriteFormatJSON     = "json"  // a single pretty-printed JSON array of all rows
+	WriteFormatMarkdown = "md"    // a Markdown table
+	WriteFormatJSONL    = "jsonl" // one JSON value per line (passthrough)
+)
+
 type Step struct {
 	Type           StepType    `yaml:"type,omitempty"`
 	Name           string      `yaml:"name"`
@@ -69,8 +77,9 @@ type Step struct {
 	Run            string      `yaml:"run"`
 	JQ             string      `yaml:"jq"`           // transform steps: jq program
 	Read           string      `yaml:"read"`         // read steps: file/glob/dir to load as rows
-	Format         string      `yaml:"format"`       // read steps: "files" | "csv" | "jsonl" (default: by extension)
-	From           string      `yaml:"from"`         // transform steps: source step name
+	Write          string      `yaml:"write"`        // write steps: file path to export the source rows to
+	Format         string      `yaml:"format"`       // read: "files"|"csv"|"jsonl"; write: "csv"|"json"|"md"|"jsonl" (default: by extension)
+	From           string      `yaml:"from"`         // transform/write steps: source step name
 	Limit          int         `yaml:"limit"`        // transform steps: cap output rows (0 = no cap)
 	Collect        bool        `yaml:"collect"`      // transform steps: jq sees an array of ALL source rows (fan-in)
 	SourceFormat   string      `yaml:"sourceFormat"` // transform steps: "jsonl" (default, line per row) or "json" (whole file is one value)

--- a/examples/v1/README.md
+++ b/examples/v1/README.md
@@ -6,6 +6,8 @@ Each folder is a self-contained `config.yaml` + `README.md`. New to datamatic? R
 | --- | --- | --- |
 | [basics](./basics) | text generation, JSON schema | Ollama |
 | [process-my-files](./process-my-files) | `read` your own local files (glob/dir/CSV/JSONL) → rows | Ollama |
+| [csv-enrichment](./csv-enrichment) | `read` CSV → enrich with LLM → `write` CSV (the full office loop) | Ollama |
+| [inbox-triage](./inbox-triage) | `read` folder of emails → SGR triage → draft replies → `write` CSV + Markdown | Ollama |
 | [linked-steps](./linked-steps) | step chaining, native template values (`if`/`range`/`len`) | Ollama |
 | [structured-extraction](./structured-extraction) | nested schema, both schema formats (YAML / JSON-string), native templates | Ollama |
 | [dataset-pipeline](./dataset-pipeline) | transform fan-out, fan-in (`collect`, `$parent`), rating pipeline | Ollama |

--- a/examples/v1/csv-enrichment/README.md
+++ b/examples/v1/csv-enrichment/README.md
@@ -1,0 +1,25 @@
+# CSV enrichment
+
+The full office loop with no shell: **read a CSV → enrich each row with an LLM → write a CSV**. Point it at your own spreadsheet of leads/rows to add labeled columns.
+
+**Features:** `read` · `forEach` · `jsonSchema` · `write`
+
+## Steps
+
+1. `leads` — `read: ./leads.csv` → one row per record (columns become fields)
+2. `classified` — `forEach` lead → `{company, industry, size}`
+3. `report` — `write: ./enriched.csv` → the enriched rows as CSV
+
+Output format is inferred from the extension (`.csv`); use `.json` for a JSON array, `.md` for a Markdown table, or set `format:` explicitly.
+
+## Requirements
+
+- `datamatic`
+- [Ollama](https://ollama.com/download) + `ollama pull qwen3:1.7b`
+
+## Run
+
+```bash
+datamatic --config ./config.yaml --verbose
+cat ./enriched.csv
+```

--- a/examples/v1/csv-enrichment/config.yaml
+++ b/examples/v1/csv-enrichment/config.yaml
@@ -1,0 +1,33 @@
+version: 1.0
+
+# The full office loop, no shell: read a CSV, enrich each row with an LLM,
+# write a CSV back out.
+steps:
+  - name: leads
+    read: ./leads.csv
+
+  - name: classified
+    model: ollama:qwen3:1.7b
+    forEach: leads
+    modelConfig:
+      temperature: 0.2
+    prompt: |
+      Company: {{.item.company}} (website: {{.item.website}}).
+      Classify its industry and likely size. Echo the company name back.
+      Return as JSON.
+    jsonSchema:
+      type: object
+      properties:
+        company:
+          type: string
+        industry:
+          type: string
+        size:
+          type: string
+          enum: [startup, smb, enterprise]
+      required: [company, industry, size]
+      additionalProperties: false
+
+  - name: report
+    from: classified
+    write: ./enriched.csv

--- a/examples/v1/csv-enrichment/leads.csv
+++ b/examples/v1/csv-enrichment/leads.csv
@@ -1,0 +1,4 @@
+company,website
+Acme Robotics,acme-robotics.example
+Globex Financial,globex.example
+Initech Software,initech.example

--- a/examples/v1/inbox-triage/README.md
+++ b/examples/v1/inbox-triage/README.md
@@ -1,0 +1,30 @@
+# Inbox triage
+
+A real support-desk loop, no shell: **read a folder of incoming emails →
+classify each with schema-guided reasoning → draft a suggested reply → write a
+triage board (CSV) and a drafts digest (Markdown)**. Drop your own `.txt`
+emails into `inbox/` and rerun.
+
+**Features:** `read` (folder of files) · `SGR` · `forEach` · `transform` · `write` (csv + md)
+
+## Steps
+
+1. `emails` — `read: ./inbox/*.txt` → one row per file (`{path, name, content}`)
+2. `triage` — `forEach` email → SGR `{reasoning, subject, category, priority, sentiment, summary}`
+3. `board_rows` — **transform** drops the reasoning, keeping the scannable columns
+4. `board` — `write: ./board.csv` → the triage board
+5. `drafts` — `forEach` triage row → `{subject, reply}` (drafted from the summary, not the raw email)
+6. `reply_digest` — `write: ./replies.md` → the suggested replies as a Markdown table
+
+## Requirements
+
+- `datamatic`
+- [Ollama](https://ollama.com/download) + `ollama pull qwen3:1.7b`
+
+## Run
+
+```bash
+datamatic --config ./config.yaml --verbose
+cat ./board.csv
+cat ./replies.md
+```

--- a/examples/v1/inbox-triage/config.yaml
+++ b/examples/v1/inbox-triage/config.yaml
@@ -1,0 +1,82 @@
+version: 1.0
+
+# Support inbox triage — the full office loop, no shell:
+# read a folder of incoming emails → classify each with SGR reasoning →
+# shape a scannable board → draft a suggested reply → write CSV + Markdown.
+steps:
+  - name: emails
+    read: ./inbox/*.txt
+
+  - name: triage
+    model: ollama:qwen3:1.7b
+    forEach: emails
+    modelConfig:
+      temperature: 0.2
+    prompt: |
+      You are a support-desk triage assistant. Read the incoming email, reason
+      through it first, then classify it.
+
+      Email ({{.item.name}}):
+      {{.item.content}}
+
+      Return as JSON.
+    jsonSchema:
+      type: object
+      properties:
+        reasoning:
+          type: string
+          description: "Brief reasoning behind the classification (SGR)."
+        subject:
+          type: string
+          description: "Copy the email's `Subject:` line verbatim."
+        category:
+          type: string
+          enum: [bug, billing, feature_request, account, other]
+        priority:
+          type: string
+          enum: [low, medium, high, urgent]
+        sentiment:
+          type: string
+          enum: [positive, neutral, negative]
+        summary:
+          type: string
+          description: "One sentence: what the customer wants."
+      required: [reasoning, subject, category, priority, sentiment, summary]
+      additionalProperties: false
+
+  # shape the board: drop the SGR reasoning, keep the scannable columns
+  - name: board_rows
+    from: triage
+    jq: '{subject, category, priority, sentiment, summary}'
+
+  - name: board
+    from: board_rows
+    write: ./board.csv
+
+  - name: drafts
+    model: ollama:qwen3:1.7b
+    forEach: triage
+    modelConfig:
+      temperature: 0.4
+    prompt: |
+      Draft a short, friendly support reply. Acknowledge the issue and give one
+      clear next step. Keep it under 120 words.
+
+      Subject: {{.item.subject}}
+      Category: {{.item.category}}
+      Customer wants: {{.item.summary}}
+
+      Return as JSON.
+    jsonSchema:
+      type: object
+      properties:
+        subject:
+          type: string
+        reply:
+          type: string
+      required: [subject, reply]
+      additionalProperties: false
+
+  - name: reply_digest
+    from: drafts
+    write: ./replies.md

--- a/examples/v1/inbox-triage/inbox/01-locked-out.txt
+++ b/examples/v1/inbox-triage/inbox/01-locked-out.txt
@@ -1,0 +1,11 @@
+From: dana.reyes@brightsail.io
+Subject: Locked out after the weekend maintenance
+
+Hi support,
+
+Since your Sunday maintenance window I can't log in to the dashboard at all.
+I reset my password twice, but after entering the code from the email the page
+just spins and eventually says "session expired". Three people on my team hit
+the same wall this morning and we have a client demo at 2pm. Please help ASAP.
+
+Dana

--- a/examples/v1/inbox-triage/inbox/02-double-charge.txt
+++ b/examples/v1/inbox-triage/inbox/02-double-charge.txt
@@ -1,0 +1,11 @@
+From: marcus@nordfeld-consulting.com
+Subject: Charged twice for the October invoice
+
+Hello,
+
+I was billed EUR 240 twice on October 3rd for the Team plan, but I only have a
+single subscription. Could you refund the duplicate charge and confirm it will
+not happen again? The two invoice numbers are INV-4471 and INV-4472.
+
+Thanks,
+Marcus

--- a/examples/v1/inbox-triage/inbox/03-feature-wishlist.txt
+++ b/examples/v1/inbox-triage/inbox/03-feature-wishlist.txt
@@ -1,0 +1,11 @@
+From: priya.n@quantaleap.dev
+Subject: Any plans for dark mode or outbound webhooks?
+
+Hey team,
+
+Really enjoying the product so far. Two things on our wishlist: a dark theme for
+the console (we stare at it all day) and outbound webhooks so we can push events
+into our own Slack. Neither is urgent, just wanted to put them on your radar.
+
+Cheers,
+Priya

--- a/examples/v1/inbox-triage/inbox/04-thanks-and-seats.txt
+++ b/examples/v1/inbox-triage/inbox/04-thanks-and-seats.txt
@@ -1,0 +1,11 @@
+From: t.oyelaran@meridianhealth.org
+Subject: Thank you, and we would like to add seats
+
+Hi,
+
+Just wanted to say the new reporting export saved us hours this quarter, great
+work. On a related note, we would like to add 5 more seats to our account. What
+is the easiest way to do that mid-cycle?
+
+Best,
+Tunde

--- a/fs/write.go
+++ b/fs/write.go
@@ -1,0 +1,111 @@
+package fs
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// unionKeys returns the sorted union of keys across all row objects, so column
+// order is deterministic regardless of per-row key variation.
+func unionKeys(rows []map[string]interface{}) []string {
+	seen := map[string]struct{}{}
+	for _, r := range rows {
+		for k := range r {
+			seen[k] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// cellString renders a value for a CSV/Markdown cell: strings verbatim, nil as
+// empty, everything else (numbers, bools, nested objects/arrays) as JSON — which
+// keeps numbers exact and avoids scientific notation.
+func cellString(v interface{}) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		b, _ := json.Marshal(t)
+		return string(b)
+	}
+}
+
+// WriteCSV writes rows as CSV; the header is the sorted union of keys and nested
+// values are JSON-encoded into their cell.
+func WriteCSV(path string, rows []map[string]interface{}) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create '%s': %w", path, err)
+	}
+	defer file.Close()
+
+	w := csv.NewWriter(file)
+	keys := unionKeys(rows)
+	if err := w.Write(keys); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		record := make([]string, len(keys))
+		for i, k := range keys {
+			record[i] = cellString(row[k])
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+// WriteJSONArray writes all rows as one pretty-printed JSON array.
+func WriteJSONArray(path string, rows []interface{}) error {
+	if rows == nil {
+		rows = []interface{}{}
+	}
+	data, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal rows: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("failed to write '%s': %w", path, err)
+	}
+	return nil
+}
+
+// WriteMarkdownTable writes rows as a GitHub-flavored Markdown table; the header
+// is the sorted union of keys, and cell newlines/pipes are escaped.
+func WriteMarkdownTable(path string, rows []map[string]interface{}) error {
+	keys := unionKeys(rows)
+
+	var b strings.Builder
+	b.WriteString("| " + strings.Join(keys, " | ") + " |\n")
+	b.WriteString("|" + strings.Repeat(" --- |", len(keys)) + "\n")
+	for _, row := range rows {
+		cells := make([]string, len(keys))
+		for i, k := range keys {
+			cells[i] = mdEscape(cellString(row[k]))
+		}
+		b.WriteString("| " + strings.Join(cells, " | ") + " |\n")
+	}
+
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("failed to write '%s': %w", path, err)
+	}
+	return nil
+}
+
+func mdEscape(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.ReplaceAll(s, "|", "\\|")
+}

--- a/fs/write_test.go
+++ b/fs/write_test.go
@@ -1,0 +1,69 @@
+package fs
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteCSV(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "out.csv")
+	rows := []map[string]interface{}{
+		{"name": "Acme", "score": float64(9)},
+		{"name": "Globex", "tags": []interface{}{"a", "b"}}, // differing keys + nested
+	}
+
+	require.NoError(t, WriteCSV(p, rows))
+
+	f, err := os.Open(p)
+	require.NoError(t, err)
+	defer f.Close()
+	recs, err := csv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"name", "score", "tags"}, recs[0], "header = sorted union of keys")
+	assert.Equal(t, []string{"Acme", "9", ""}, recs[1], "missing key → empty; number verbatim")
+	assert.Equal(t, []string{"Globex", "", `["a","b"]`}, recs[2], "nested value JSON-encoded")
+}
+
+func TestWriteJSONArray(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "out.json")
+	rows := []interface{}{
+		map[string]interface{}{"a": float64(1)},
+		map[string]interface{}{"a": float64(2)},
+	}
+
+	require.NoError(t, WriteJSONArray(p, rows))
+
+	data, err := os.ReadFile(p)
+	require.NoError(t, err)
+	var back []map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &back))
+	require.Len(t, back, 2)
+	assert.Equal(t, float64(1), back[0]["a"])
+	assert.Contains(t, string(data), "\n", "pretty-printed")
+}
+
+func TestWriteMarkdownTable(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "out.md")
+	rows := []map[string]interface{}{
+		{"name": "Acme", "score": float64(9)},
+		{"name": "Globex", "score": float64(4)},
+	}
+
+	require.NoError(t, WriteMarkdownTable(p, rows))
+
+	data, err := os.ReadFile(p)
+	require.NoError(t, err)
+	got := string(data)
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	assert.Equal(t, "| name | score |", lines[0])
+	assert.Equal(t, "| --- | --- |", lines[1])
+	assert.Contains(t, got, "| Acme | 9 |")
+}

--- a/jsonschema/types.go
+++ b/jsonschema/types.go
@@ -183,4 +183,16 @@ func walkStrict(node *jsonschema.Schema, path string, issues *[]string) {
 	if node.Items != nil {
 		walkStrict(node.Items, path+".items", issues)
 	}
+
+	// routing unions: every branch must itself be a strict object, otherwise
+	// it passes here but fails on OpenAI strict structured output
+	walkBranches(node.AnyOf, path+".anyOf", issues)
+	walkBranches(node.OneOf, path+".oneOf", issues)
+	walkBranches(node.AllOf, path+".allOf", issues)
+}
+
+func walkBranches(branches []*jsonschema.Schema, path string, issues *[]string) {
+	for i, branch := range branches {
+		walkStrict(branch, fmt.Sprintf("%s[%d]", path, i), issues)
+	}
 }

--- a/jsonschema/types_test.go
+++ b/jsonschema/types_test.go
@@ -252,6 +252,48 @@ func TestValidateJSONText(t *testing.T) {
 	assert.Contains(t, errorMsg, "Properties 'age', 'email', 'name' do not match their schemas")
 }
 
+// TestValidateJSONText_DiscriminatedUnion proves the engine correctly enforces
+// an SGR-routing union: exactly one branch's shape must match, and a payload
+// that mixes branches or adds fields is rejected. This is the deterministic
+// verification of Routing support (LLM branch-choice accuracy is model-bound
+// and out of scope here).
+func TestValidateJSONText_DiscriminatedUnion(t *testing.T) {
+	schema, err := LoadSchema(`{
+		"type": "object",
+		"properties": {
+			"details": {
+				"anyOf": [
+					{
+						"type": "object",
+						"properties": {"kind": {"const": "billing"}, "amount_note": {"type": "string"}},
+						"required": ["kind", "amount_note"],
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"properties": {"kind": {"const": "bug"}, "affected_area": {"type": "string"}},
+						"required": ["kind", "affected_area"],
+						"additionalProperties": false
+					}
+				]
+			}
+		},
+		"required": ["details"],
+		"additionalProperties": false
+	}`)
+	require.NoError(t, err)
+
+	assert.NoError(t, schema.ValidateJSONText(`{"details": {"kind": "billing", "amount_note": "EUR 240 x2"}}`),
+		"a well-formed billing branch must pass")
+	assert.NoError(t, schema.ValidateJSONText(`{"details": {"kind": "bug", "affected_area": "login"}}`),
+		"a well-formed bug branch must pass")
+
+	assert.Error(t, schema.ValidateJSONText(`{"details": {"kind": "billing", "affected_area": "login"}}`),
+		"mixing a branch's discriminator with another branch's fields must fail")
+	assert.Error(t, schema.ValidateJSONText(`{"details": {"kind": "bug", "affected_area": "login", "severity": "high"}}`),
+		"an extra field not in the chosen branch must fail (additionalProperties: false)")
+}
+
 func TestHasFieldPath(t *testing.T) {
 	schema, err := LoadSchema(map[string]interface{}{
 		"type": "object",
@@ -353,6 +395,58 @@ func TestStrictCompatibilityIssues_CleanSchema(t *testing.T) {
 		"type": "object",
 		"properties": {"title": {"type": "string"}},
 		"required": ["title"],
+		"additionalProperties": false
+	}`)
+	require.NoError(t, err)
+
+	assert.Empty(t, schema.StrictCompatibilityIssues())
+}
+
+func TestStrictCompatibilityIssues_UnionBranch(t *testing.T) {
+	// a routing union whose branch is not strict: 'note' is optional and
+	// additionalProperties is not false
+	schema, err := LoadSchema(`{
+		"type": "object",
+		"properties": {
+			"issue": {
+				"anyOf": [
+					{
+						"type": "object",
+						"properties": {"kind": {"type": "string"}, "note": {"type": "string"}},
+						"required": ["kind"]
+					}
+				]
+			}
+		},
+		"required": ["issue"],
+		"additionalProperties": false
+	}`)
+	require.NoError(t, err)
+
+	issues := schema.StrictCompatibilityIssues()
+
+	assert.NotEmpty(t, issues)
+	joined := strings.Join(issues, "; ")
+	assert.Contains(t, joined, "anyOf", "must point at the offending union branch")
+	assert.Contains(t, joined, "note", "optional branch property must be flagged")
+}
+
+func TestStrictCompatibilityIssues_CleanUnionBranch(t *testing.T) {
+	schema, err := LoadSchema(`{
+		"type": "object",
+		"properties": {
+			"issue": {
+				"anyOf": [
+					{
+						"type": "object",
+						"properties": {"kind": {"type": "string"}},
+						"required": ["kind"],
+						"additionalProperties": false
+					}
+				]
+			}
+		},
+		"required": ["issue"],
 		"additionalProperties": false
 	}`)
 	require.NoError(t, err)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -139,3 +139,38 @@ func readOutputLines(t *testing.T, path string) []string {
 	}
 	return lines
 }
+
+func TestRun_ReadEnrichWritePipeline(t *testing.T) {
+	// read a CSV -> classify each row -> write the result back as CSV
+	srv := llmtest.NewServer(t, `{"industry":"tech"}`, `{"industry":"finance"}`)
+
+	srcDir := t.TempDir() // user's input files, separate from the output folder
+	leads := filepath.Join(srcDir, "leads.csv")
+	require.NoError(t, os.WriteFile(leads, []byte("company\nAcme\nGlobex\n"), 0o644))
+	out := filepath.Join(srcDir, "enriched.csv")
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = t.TempDir()
+	cfg.Version = "1.0"
+	cfg.Steps = []config.Step{
+		{Name: "leads", Read: leads},
+		{
+			Name: "classify", Model: "ollama:test-model", ForEach: "leads",
+			Prompt:        "Industry of {{.item.company}}?",
+			JSONSchemaRaw: `{"type":"object","properties":{"industry":{"type":"string"}},"required":["industry"],"additionalProperties":false}`,
+			ModelConfig:   config.ModelConfig{BaseURL: srv.URL},
+		},
+		{Name: "report", From: "classify", Write: out},
+	}
+
+	require.NoError(t, utils.PreprocessConfig(cfg))
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, runner.NewRunner(cfg).Run(context.Background()))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	got := string(data)
+	assert.Contains(t, got, "industry")
+	assert.Contains(t, got, "tech")
+	assert.Contains(t, got, "finance")
+}

--- a/step/read_step.go
+++ b/step/read_step.go
@@ -15,8 +15,9 @@ import (
 type ReadStep struct{}
 
 // Run loads local files into JSONL rows: one row per file (files), per record
-// (csv), or per line (jsonl). The read path resolves relative to the current
-// working directory; rows materialize to OutputFilename like a transform step.
+// (csv), or per line (jsonl). The read path is resolved during preprocessing
+// (relative to the config file's dir); rows materialize to OutputFilename like
+// a transform step.
 func (p *ReadStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
 	files, err := fs.GlobFiles(step.Read)
 	if err != nil {

--- a/step/step.go
+++ b/step/step.go
@@ -21,6 +21,8 @@ func NewStepRunner(step config.Step) (StepRunner, error) {
 		return &TransformStep{}, nil
 	case config.ReadStepType:
 		return &ReadStep{}, nil
+	case config.WriteStepType:
+		return &WriteStep{}, nil
 	default:
 		return nil, errors.New("unsupported step type")
 	}

--- a/step/transform_step.go
+++ b/step/transform_step.go
@@ -111,22 +111,9 @@ func runPerRow(ctx context.Context, srcStep config.Step, step config.Step, src i
 // runCollect gathers all source rows into one array and runs the jq program
 // once over it (fan-in: unique, group_by, sort_by across the whole dataset).
 func runCollect(ctx context.Context, srcStep config.Step, step config.Step, src io.Reader, writer *jsonl.Writer) error {
-	var collected []interface{}
-	scanner := fs.NewLineScanner(src)
-	for lineNo := 0; scanner.Scan(); lineNo++ {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		value, _, _, err := getSourceDataFromLine(srcStep, scanner.Text())
-		if err != nil {
-			return fmt.Errorf("line %d: %w", lineNo, err)
-		}
-
-		collected = append(collected, value)
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to read source: %w", err)
+	collected, err := collectRows(ctx, srcStep, src)
+	if err != nil {
+		return err
 	}
 
 	written := 0
@@ -136,6 +123,27 @@ func runCollect(ctx context.Context, srcStep config.Step, step config.Step, src 
 
 	log.Info().Msgf("transform produced %d rows", written)
 	return nil
+}
+
+// collectRows scans a source step's output, decoding every line into its row
+// value via the shared decoder. Used by transform collect and write steps.
+func collectRows(ctx context.Context, srcStep config.Step, r io.Reader) ([]interface{}, error) {
+	var rows []interface{}
+	scanner := fs.NewLineScanner(r)
+	for lineNo := 0; scanner.Scan(); lineNo++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		value, _, _, err := getSourceDataFromLine(srcStep, scanner.Text())
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		rows = append(rows, value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read source: %w", err)
+	}
+	return rows, nil
 }
 
 // limitedEmit returns a RunEach callback that writes emitted values until the

--- a/step/write_step.go
+++ b/step/write_step.go
@@ -1,0 +1,93 @@
+package step
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/mirpo/datamatic/fs"
+	"github.com/rs/zerolog/log"
+)
+
+type WriteStep struct{}
+
+// Run exports a source step's rows to a single file in the configured format
+// (csv / json / md / jsonl). It is terminal — it reads the source's JSONL and
+// writes the deliverable; it does not produce pipeline rows itself.
+func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
+	src := cfg.GetStepByName(step.From)
+	if src == nil {
+		return fmt.Errorf("'from' references unknown step '%s'", step.From)
+	}
+
+	file, err := os.Open(src.OutputFilename)
+	if err != nil {
+		return fmt.Errorf("step '%s': failed to open source '%s': %w", step.Name, src.OutputFilename, err)
+	}
+	defer file.Close()
+
+	rows, err := collectRows(ctx, *src, file)
+	if err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
+	}
+
+	switch step.Format {
+	case config.WriteFormatJSON:
+		if err := fs.WriteJSONArray(step.Write, rows); err != nil {
+			return err
+		}
+	case config.WriteFormatJSONL:
+		if err := writeJSONL(step.Write, rows); err != nil {
+			return err
+		}
+	case config.WriteFormatCSV, config.WriteFormatMarkdown:
+		objs, err := asObjects(rows)
+		if err != nil {
+			return fmt.Errorf("step '%s': %w", step.Name, err)
+		}
+		// WriteCSV and WriteMarkdownTable share a signature — pick by format
+		writeTable := fs.WriteCSV
+		if step.Format == config.WriteFormatMarkdown {
+			writeTable = fs.WriteMarkdownTable
+		}
+		if err := writeTable(step.Write, objs); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("step '%s': unknown write format '%s'", step.Name, step.Format)
+	}
+
+	log.Info().Msgf("write exported %d rows to %s", len(rows), step.Write)
+	return nil
+}
+
+// asObjects asserts every row is a JSON object (required for csv/md columns).
+func asObjects(rows []interface{}) ([]map[string]interface{}, error) {
+	objs := make([]map[string]interface{}, 0, len(rows))
+	for i, r := range rows {
+		obj, ok := r.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("row %d is not a JSON object; csv/md output needs object rows (use json/jsonl instead)", i)
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+func writeJSONL(path string, rows []interface{}) error {
+	file, err := os.Create(path) // truncate: a fresh deliverable each run
+	if err != nil {
+		return fmt.Errorf("failed to create '%s': %w", path, err)
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file) // Encode writes one compact JSON value + newline
+	for _, row := range rows {
+		if err := enc.Encode(row); err != nil {
+			return fmt.Errorf("failed to write row: %w", err)
+		}
+	}
+	return nil
+}

--- a/step/write_step_test.go
+++ b/step/write_step_test.go
@@ -1,0 +1,77 @@
+package step
+
+import (
+	"context"
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mirpo/datamatic/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeStepSetup(t *testing.T, srcLines, format, ext string) (config.Step, string) {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.jsonl")
+	require.NoError(t, os.WriteFile(srcPath, []byte(srcLines), 0o644))
+
+	out := filepath.Join(dir, "out."+ext)
+	cfg := config.NewConfig()
+	cfg.Steps = []config.Step{{Name: "data", Type: config.TransformStepType, OutputFilename: srcPath}}
+	step := config.Step{
+		Name: "report", Type: config.WriteStepType, From: "data",
+		Write: out, Format: format, OutputFilename: out,
+	}
+	require.NoError(t, (&WriteStep{}).Run(context.Background(), cfg, step, dir))
+	return step, out
+}
+
+func TestWriteStepRun_CSV(t *testing.T) {
+	_, out := writeStepSetup(t,
+		`{"name":"Acme","score":9}`+"\n"+`{"name":"Globex","score":4}`+"\n",
+		config.WriteFormatCSV, "csv")
+
+	f, err := os.Open(out)
+	require.NoError(t, err)
+	defer f.Close()
+	recs, err := csv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"name", "score"}, recs[0])
+	assert.Equal(t, []string{"Acme", "9"}, recs[1])
+	assert.Equal(t, []string{"Globex", "4"}, recs[2])
+}
+
+func TestWriteStepRun_JSONLPassthrough(t *testing.T) {
+	_, out := writeStepSetup(t,
+		`{"a":1}`+"\n"+`{"a":2}`+"\n",
+		config.WriteFormatJSONL, "jsonl")
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":1}`+"\n"+`{"a":2}`+"\n", string(data))
+}
+
+func TestWriteStepRun_UnknownSourceFails(t *testing.T) {
+	cfg := config.NewConfig()
+	step := config.Step{Name: "report", Type: config.WriteStepType, From: "ghost", Write: "/tmp/x.csv", Format: config.WriteFormatCSV, OutputFilename: "/tmp/x.csv"}
+	err := (&WriteStep{}).Run(context.Background(), cfg, step, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestWriteStepRun_NonObjectRowFailsCSV(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.jsonl")
+	require.NoError(t, os.WriteFile(srcPath, []byte(`"just a string"`+"\n"), 0o644))
+	cfg := config.NewConfig()
+	cfg.Steps = []config.Step{{Name: "data", Type: config.TransformStepType, OutputFilename: srcPath}}
+	out := filepath.Join(dir, "out.csv")
+	step := config.Step{Name: "report", Type: config.WriteStepType, From: "data", Write: out, Format: config.WriteFormatCSV, OutputFilename: out}
+
+	err := (&WriteStep{}).Run(context.Background(), cfg, step, dir)
+	require.Error(t, err, "csv needs object rows")
+}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -24,9 +24,9 @@ const jqParentVar = "$parent"
 // setStepType determines and sets the step type based on step configuration
 func setStepType(step *config.Step) error {
 	switch step.Type {
-	case "", config.PromptStepType, config.ShellStepType, config.TransformStepType, config.ReadStepType:
+	case "", config.PromptStepType, config.ShellStepType, config.TransformStepType, config.ReadStepType, config.WriteStepType:
 	default:
-		return fmt.Errorf("unknown step type '%s' (expected 'prompt', 'shell', 'transform' or 'read')", step.Type)
+		return fmt.Errorf("unknown step type '%s' (expected 'prompt', 'shell', 'transform', 'read' or 'write')", step.Type)
 	}
 
 	var inferred config.StepType
@@ -44,8 +44,11 @@ func setStepType(step *config.Step) error {
 	if step.Read != "" {
 		inferred, sourceField, count = config.ReadStepType, "read", count+1
 	}
+	if step.Write != "" {
+		inferred, sourceField, count = config.WriteStepType, "write", count+1
+	}
 	if count != 1 {
-		return errors.New("exactly one of 'prompt', 'run', 'jq' or 'read' must be defined")
+		return errors.New("exactly one of 'prompt', 'run', 'jq', 'read' or 'write' must be defined")
 	}
 
 	if step.Type != "" && step.Type != inferred {
@@ -156,6 +159,16 @@ func PreprocessConfig(cfg *config.Config) error {
 		if step.Image != "" && step.Type != config.PromptStepType {
 			return fmt.Errorf("step '%s': 'image' is only valid on prompt steps", step.Name)
 		}
+		if step.Format != "" && step.Type != config.ReadStepType && step.Type != config.WriteStepType {
+			return fmt.Errorf("step '%s': 'format' is only valid on read and write steps", step.Name)
+		}
+		// a write step is terminal — it produces a deliverable file, not pipeline
+		// rows — so it may not be used as a source
+		for _, ref := range []struct{ field, name string }{{"from", step.From}, {"forEach", step.ForEach}} {
+			if src := stepByName[ref.name]; ref.name != "" && src != nil && src.Type == config.WriteStepType {
+				return fmt.Errorf("step '%s': cannot use write step '%s' as a '%s' source", step.Name, ref.name, ref.field)
+			}
+		}
 		if step.Type == config.TransformStepType {
 			if step.From == "" {
 				return fmt.Errorf("step '%s': 'from' is required for transform steps", step.Name)
@@ -194,9 +207,10 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Read steps: local-file source (path resolves relative to CWD; rows
-		// materialize to outputFolder like a transform)
+		// Read steps: local-file source (path resolves relative to the config
+		// file's dir; rows materialize to outputFolder like a transform)
 		if step.Type == config.ReadStepType {
+			step.Read = resolveDataPath(cfg.ConfigFile, step.Read)
 			format, err := resolveReadFormat(step)
 			if err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
@@ -205,6 +219,24 @@ func PreprocessConfig(cfg *config.Config) error {
 			if err := setOutputFilename(step, cfg.OutputFolder); err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
 			}
+		}
+
+		// Write steps: terminal export of a source step's rows to a file
+		// (path resolves relative to the config file's dir — the deliverable)
+		if step.Type == config.WriteStepType {
+			if step.From == "" {
+				return fmt.Errorf("step '%s': 'from' is required for write steps", step.Name)
+			}
+			if err := requireEarlierStep(stepNames, "from", step.From); err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			step.Write = resolveDataPath(cfg.ConfigFile, step.Write)
+			format, err := resolveWriteFormat(step)
+			if err != nil {
+				return fmt.Errorf("step '%s': %w", step.Name, err)
+			}
+			step.Format = format
+			step.OutputFilename = step.Write
 		}
 
 		if err := validateIterationSettings(step, stepNames); err != nil {
@@ -244,6 +276,9 @@ func validatePromptPlaceholders(step *config.Step, stepByName map[string]*config
 		refStep, ok := stepByName[ref.Step]
 		if !ok {
 			return fmt.Errorf("prompt references unknown step '%s' (must be an earlier step)", ref.Step)
+		}
+		if refStep.Type == config.WriteStepType {
+			return fmt.Errorf("prompt references write step '%s', which is terminal and produces no rows", ref.Step)
 		}
 
 		if keysByStep[ref.Step] == nil {
@@ -327,6 +362,16 @@ func getFullOutputPath(step config.Step, outputFolder string) (string, error) {
 	return filepath.Clean(fullPath), nil
 }
 
+// resolveDataPath makes a relative read/write path relative to the config
+// file's directory, so a workflow's data files travel with it and it runs from
+// any working directory. Absolute paths are left unchanged.
+func resolveDataPath(configFile, path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(filepath.Dir(configFile), path)
+}
+
 // resolveReadFormat validates an explicit read `format` or infers it from the
 // path's extension (.csv/.tsv → csv, .jsonl → jsonl, otherwise files).
 func resolveReadFormat(step *config.Step) (string, error) {
@@ -346,6 +391,32 @@ func resolveReadFormat(step *config.Step) (string, error) {
 		return config.ReadFormatJSONL, nil
 	default:
 		return config.ReadFormatFiles, nil
+	}
+}
+
+// resolveWriteFormat validates an explicit write `format` or infers it from the
+// output path's extension (.csv/.tsv → csv, .json → json, .md → md, .jsonl → jsonl).
+func resolveWriteFormat(step *config.Step) (string, error) {
+	if step.Format != "" {
+		switch step.Format {
+		case config.WriteFormatCSV, config.WriteFormatJSON, config.WriteFormatMarkdown, config.WriteFormatJSONL:
+			return step.Format, nil
+		default:
+			return "", fmt.Errorf("unknown format '%s' (expected 'csv', 'json', 'md' or 'jsonl')", step.Format)
+		}
+	}
+
+	switch strings.ToLower(filepath.Ext(step.Write)) {
+	case ".csv", ".tsv":
+		return config.WriteFormatCSV, nil
+	case ".json":
+		return config.WriteFormatJSON, nil
+	case ".md", ".markdown":
+		return config.WriteFormatMarkdown, nil
+	case ".jsonl":
+		return config.WriteFormatJSONL, nil
+	default:
+		return "", fmt.Errorf("cannot infer output format from '%s' — set 'format' explicitly (csv/json/md/jsonl)", step.Write)
 	}
 }
 

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/llm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsValidName(t *testing.T) {
@@ -158,7 +159,7 @@ func TestPreprocessConfig_Failures(t *testing.T) {
 			&config.Config{OutputFolder: "/tmp", Steps: []config.Step{
 				{Name: "bad", Prompt: "p", Run: "c"},
 			}},
-			"exactly one of 'prompt', 'run', 'jq' or 'read' must be defined",
+			"exactly one of 'prompt', 'run', 'jq', 'read' or 'write' must be defined",
 		},
 		{
 			"Missing provider colon",
@@ -631,4 +632,75 @@ func TestPreprocessConfig_ReadStep(t *testing.T) {
 		cfg.Steps[0].Image = "*.jpg"
 		assert.ErrorContains(t, PreprocessConfig(cfg), "image")
 	})
+}
+
+func TestPreprocessConfig_WriteStep(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 2},
+			{Name: "out", From: "gen", Write: "./out.csv"},
+		}
+		return cfg
+	}
+
+	t.Run("valid write infers csv", func(t *testing.T) {
+		cfg := base()
+		assert.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.WriteStepType, cfg.Steps[1].Type)
+		assert.Equal(t, config.WriteFormatCSV, cfg.Steps[1].Format)
+	})
+	t.Run("missing from fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].From = ""
+		assert.ErrorContains(t, PreprocessConfig(cfg), "'from' is required")
+	})
+	t.Run("unknown extension without format fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Write = "./out.parquet"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "cannot infer output format")
+	})
+	t.Run("explicit format overrides extension", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Write = "./out.dat"
+		cfg.Steps[1].Format = config.WriteFormatJSON
+		assert.NoError(t, PreprocessConfig(cfg))
+	})
+	t.Run("write step cannot be a from source", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{Name: "again", From: "out", JQ: "."})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "cannot use write step 'out'")
+	})
+	t.Run("write step cannot be a forEach source", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps = append(cfg.Steps, config.Step{Name: "again", ForEach: "out", Prompt: "p", Model: "ollama:m"})
+		assert.ErrorContains(t, PreprocessConfig(cfg), "cannot use write step 'out'")
+	})
+	t.Run("format on a prompt step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Format = "csv"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "'format' is only valid on read and write")
+	})
+}
+
+func TestPreprocessConfig_DataPathsResolveToConfigDir(t *testing.T) {
+	// a genuinely absolute path for the current platform (a bare "/abs/x" is
+	// NOT absolute on Windows, which needs a drive letter)
+	absIn := filepath.Join(t.TempDir(), "x.csv")
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = t.TempDir()
+	cfg.ConfigFile = filepath.Join("some", "dir", "config.yaml")
+	cfg.Steps = []config.Step{
+		{Name: "in", Read: "./data/*.md"},
+		{Name: "rel_out", From: "in", Write: "results.csv"},
+		{Name: "abs_in", Read: absIn},
+	}
+
+	require.NoError(t, PreprocessConfig(cfg))
+
+	assert.Equal(t, filepath.Join("some", "dir", "data", "*.md"), cfg.Steps[0].Read, "relative read → config dir")
+	assert.Equal(t, filepath.Join("some", "dir", "results.csv"), cfg.Steps[1].Write, "relative write → config dir")
+	assert.Equal(t, absIn, cfg.Steps[2].Read, "absolute read unchanged")
 }


### PR DESCRIPTION
## Summary
Adds a terminal `write:` step and closes the **read → LLM → write** office loop with no shell glue. Also makes local-file paths config-relative and teaches the schema strict-checker about discriminated unions (SGR routing).

## What's in it
- **`write:` step** — exports a source step's rows to a deliverable file: `.csv` (sorted union header, JSON-encoded nested cells), `.json` (pretty array), `.md` (table), `.jsonl`; format inferred from extension or `format:` override. Terminal (can't be a `from`/`forEach`/placeholder source). `fs/write.go` + `step/write_step.go`; shared `collectRows` extracted from transform-collect (no JSONL-plane change).
- **Config-relative paths** — relative `read:`/`write:` paths now resolve to the **config file's directory** (absolute paths unchanged), so a workflow's data travels with it and runs from any working directory. Applies to both `read` (was CWD-relative) and `write`.
- **SGR Routing (engine)** — the strict-compat walker (`jsonschema`) now recurses `anyOf`/`oneOf`/`allOf` branches, so discriminated-union schemas are validated for OpenAI strict output. Deterministic tests: `TestStrictCompatibilityIssues_UnionBranch`, `TestValidateJSONText_DiscriminatedUnion`.
- **Examples** — `csv-enrichment` (minimal read→enrich→write) and `inbox-triage` (read emails → SGR triage → jq board → draft replies → write csv + md).
- **Docs** — README "Schema-Guided Reasoning (SGR)" section (Cascade / Routing / Cycle). Routing documented as a **cloud-model pattern**: small local models (≤3B) reliably mis-route `anyOf` unions (verified across qwen3:1.7b, llama3.2:3b, deepseek-r1:1.5b), so the local examples use Cascade.

## Verification
- Build + full `go test ./...` + `golangci-lint` green.
- Both examples run end-to-end from a foreign working directory; deliverables land next to their config (config-relative confirmed live).

## Note
Path model has a known open follow-up (intermediate JSONL/`dataset/` still resolves CWD-relative while `read`/`write` are config-relative; `--output` control) — tracked separately, out of scope here.