### PR TITLE
feat!: one output-path model, and stop rotating the output folder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,5 +65,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ollama pull qwen3:1.7b
+          # no --output: exercises the default, which is 'dataset' next to the config
           ./datamatic --config ci/smoke.yaml --verbose
-          cat ./dataset/describe.jsonl | jq
+          cat ./ci/dataset/describe.jsonl | jq

--- a/README.md
+++ b/README.md
@@ -303,13 +303,26 @@ Options:
   -log-pretty
         Enable pretty logging, JSON when false (default true)
   -output string
-        Output folder path (default "dataset")
+        Output folder path, relative to the working directory
+        (default: 'dataset' next to the config file)
   -validate-response
         Validate JSON response from server to match the schema (default true)
   -verbose
         Enable DEBUG logging level
   -version
         Get current version of datamatic
+```
+
+**Choosing the output folder** — first match wins:
+
+1. `--output <path>` — relative to the **working directory**, absolute used as-is
+2. `output:` in the config — relative to the **config file's directory**, so it travels with the workflow
+3. otherwise `dataset` **next to the config file** — the same workflow lands in the same place no matter where it was launched from
+
+```bash
+datamatic --config flows/triage/config.yaml                        # → flows/triage/dataset/
+datamatic --config flows/triage/config.yaml --output ./today       # → ./today/
+datamatic --config flows/triage/config.yaml --output /srv/runs/a   # → /srv/runs/a/
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Process your own data end to end — no shell glue:
 ```yaml
 steps:
   - name: leads
-    read: ./leads.csv          # local files → rows
+    read: leads.csv          # local files → rows
   - name: classified
     forEach: leads
     prompt: Classify {{.item.company}}

--- a/README.md
+++ b/README.md
@@ -195,10 +195,12 @@ steps:
 | --- | --- | --- |
 | `read:` (input) | the **config file's directory** — so a workflow runs from any working directory | used as-is |
 | `write:` (deliverable) | the **output folder** | used as-is — this is how you publish outside it |
-| intermediate JSONL | the **output folder** (always) | — |
+| intermediate JSONL | the **output folder** | — |
 | `--output` (flag) | the **working directory** | used as-is |
 
 The output folder is **reused and overwritten** on each run — no `dataset_v1`, `dataset_v2` copies, so deliverable paths stay stable. For run history, point `--output` somewhere per-run (e.g. `--output runs/$(date +%F-%H%M)`). `dataset*` is gitignored.
+
+One exception: a shell step with an explicit `workDir` writes its `outputFilename` into that directory (relative to the output folder, or wherever an absolute `workDir` points), since the command needs to produce the file in its own working directory.
 
 See the [csv-enrichment](./examples/v1/csv-enrichment/README.md) and [process-my-files](./examples/v1/process-my-files/README.md) examples.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ steps:
     jsonSchema: { ... }
   - name: report
     from: classified
-    write: ./enriched.csv       # rows → a deliverable file
+    write: enriched.csv         # rows → a deliverable file
 ```
 
 - **`read:`** turns local files into rows. Format is inferred from the path (overridable with `format:`):
@@ -188,7 +188,19 @@ steps:
   - `.jsonl` → one row per line
 - **`write:`** exports a step's rows to a file, format inferred from the extension: `.csv`, `.json` (array), `.md` (table), or `.jsonl`. It's terminal and doesn't change the intermediate JSONL that other steps read.
 - **`image:`** on a prompt step attaches a file as a vision image, e.g. `image: "{{.item.path}}"` after `read`-ing a folder of images.
-- Relative `read`/`write` paths resolve **relative to the config file's directory** (so a workflow's data travels with it and runs from any working directory); absolute paths are used as-is. See the [csv-enrichment](./examples/v1/csv-enrichment/README.md) and [process-my-files](./examples/v1/process-my-files/README.md) examples.
+
+**Where paths point.** Inputs travel with the workflow; everything generated lands in the output folder:
+
+| Path | Relative to | Absolute |
+| --- | --- | --- |
+| `read:` (input) | the **config file's directory** — so a workflow runs from any working directory | used as-is |
+| `write:` (deliverable) | the **output folder** | used as-is — this is how you publish outside it |
+| intermediate JSONL | the **output folder** (always) | — |
+| `--output` (flag) | the **working directory** | used as-is |
+
+The output folder is **reused and overwritten** on each run — no `dataset_v1`, `dataset_v2` copies, so deliverable paths stay stable. For run history, point `--output` somewhere per-run (e.g. `--output runs/$(date +%F-%H%M)`). `dataset*` is gitignored.
+
+See the [csv-enrichment](./examples/v1/csv-enrichment/README.md) and [process-my-files](./examples/v1/process-my-files/README.md) examples.
 
 ### Schema-Guided Reasoning (SGR)
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ func NewConfig() *Config {
 		ConfigFile:       "",
 		Verbose:          false,
 		LogPretty:        true,
-		OutputFolder:     "dataset",
 		HTTPTimeout:      300,
 		ValidateResponse: true,
 		RetryConfig:      retry.NewDefaultConfig(),
@@ -28,16 +27,24 @@ func NewConfig() *Config {
 }
 
 type Config struct {
-	ConfigFile       string
-	Verbose          bool
-	LogPretty        bool
+	ConfigFile string
+	Verbose    bool
+	LogPretty  bool
+	// OutputFlag is the --output value: a relative path is resolved against the
+	// working directory, since that is where the command was typed.
+	OutputFlag string
+	// OutputFolder is the resolved absolute folder every step writes into,
+	// computed during preprocessing.
 	OutputFolder     string
 	HTTPTimeout      int
 	ValidateResponse bool
-	Version          string       `yaml:"version"`
-	EnvVars          []string     `yaml:"envVars"`
-	Steps            []Step       `yaml:"steps"`
-	RetryConfig      retry.Config `yaml:"retryConfig"`
+	Version          string   `yaml:"version"`
+	EnvVars          []string `yaml:"envVars"`
+	// Output is the optional `output:` key: a relative path is resolved against
+	// the config file's directory, so it travels with the workflow.
+	Output      string       `yaml:"output"`
+	Steps       []Step       `yaml:"steps"`
+	RetryConfig retry.Config `yaml:"retryConfig"`
 }
 
 type StepType string

--- a/config/config.go
+++ b/config/config.go
@@ -27,17 +27,22 @@ func NewConfig() *Config {
 }
 
 type Config struct {
-	ConfigFile string
-	Verbose    bool
-	LogPretty  bool
+	// Runtime state: set from CLI flags or computed while preprocessing, never
+	// read from the config document. yaml:"-" keeps them out of the YAML
+	// namespace — without it each one is addressable by its lowercased name
+	// (`outputfolder:`, `verbose:`), which would mean several undocumented
+	// spellings of one setting, some with a different base directory.
+	ConfigFile string `yaml:"-"`
+	Verbose    bool   `yaml:"-"`
+	LogPretty  bool   `yaml:"-"`
 	// OutputFlag is the --output value: a relative path is resolved against the
 	// working directory, since that is where the command was typed.
-	OutputFlag string
+	OutputFlag string `yaml:"-"`
 	// OutputFolder is the resolved absolute folder every step writes into,
 	// computed during preprocessing.
-	OutputFolder     string
-	HTTPTimeout      int
-	ValidateResponse bool
+	OutputFolder     string   `yaml:"-"`
+	HTTPTimeout      int      `yaml:"-"`
+	ValidateResponse bool     `yaml:"-"`
 	Version          string   `yaml:"version"`
 	EnvVars          []string `yaml:"envVars"`
 	// Output is the optional `output:` key: a relative path is resolved against

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,11 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.ConfigFile)
 	assert.False(t, cfg.Verbose)
 	assert.True(t, cfg.LogPretty)
-	assert.Equal(t, "dataset", cfg.OutputFolder)
+	// the output folder is resolved during preprocessing (default: 'dataset'
+	// next to the config file), so it starts out unset
+	assert.Equal(t, "", cfg.OutputFolder)
+	assert.Equal(t, "", cfg.OutputFlag)
+	assert.Equal(t, "", cfg.Output)
 	assert.Equal(t, 300, cfg.HTTPTimeout)
 	assert.Equal(t, "", cfg.Version)
 	assert.Nil(t, cfg.Steps)

--- a/datamatic.go
+++ b/datamatic.go
@@ -37,7 +37,7 @@ func main() {
 	flag.BoolVar(&cfg.Verbose, "verbose", cfg.Verbose, "Enable DEBUG logging level")
 	flag.BoolVar(&cfg.LogPretty, "log-pretty", cfg.LogPretty, "Enable pretty logging, JSON when false")
 	flag.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "Config file path")
-	flag.StringVar(&cfg.OutputFolder, "output", cfg.OutputFolder, "Output folder path")
+	flag.StringVar(&cfg.OutputFlag, "output", "", "Output folder path, relative to the working directory (default: 'dataset' next to the config file)")
 	flag.IntVar(&cfg.HTTPTimeout, "http-timeout", cfg.HTTPTimeout, "HTTP timeout: 0 - no timeout, if number - recommended to put high on poor hardware")
 	flag.BoolVar(&cfg.ValidateResponse, "validate-response", cfg.ValidateResponse, "Validate JSON response from server to match the schema")
 

--- a/examples/v1/csv-enrichment/README.md
+++ b/examples/v1/csv-enrichment/README.md
@@ -8,7 +8,7 @@ The full office loop with no shell: **read a CSV → enrich each row with an LLM
 
 1. `leads` — `read: ./leads.csv` → one row per record (columns become fields)
 2. `classified` — `forEach` lead → `{company, industry, size}`
-3. `report` — `write: ./enriched.csv` → the enriched rows as CSV
+3. `report` — `write: enriched.csv` → the enriched rows as CSV
 
 Output format is inferred from the extension (`.csv`); use `.json` for a JSON array, `.md` for a Markdown table, or set `format:` explicitly.
 
@@ -21,5 +21,5 @@ Output format is inferred from the extension (`.csv`); use `.json` for a JSON ar
 
 ```bash
 datamatic --config ./config.yaml --verbose
-cat ./enriched.csv
+cat ./dataset/enriched.csv
 ```

--- a/examples/v1/csv-enrichment/README.md
+++ b/examples/v1/csv-enrichment/README.md
@@ -6,7 +6,7 @@ The full office loop with no shell: **read a CSV → enrich each row with an LLM
 
 ## Steps
 
-1. `leads` — `read: ./leads.csv` → one row per record (columns become fields)
+1. `leads` — `read: leads.csv` → one row per record (columns become fields)
 2. `classified` — `forEach` lead → `{company, industry, size}`
 3. `report` — `write: enriched.csv` → the enriched rows as CSV
 

--- a/examples/v1/csv-enrichment/config.yaml
+++ b/examples/v1/csv-enrichment/config.yaml
@@ -4,7 +4,7 @@ version: 1.0
 # write a CSV back out.
 steps:
   - name: leads
-    read: ./leads.csv
+    read: leads.csv
 
   - name: classified
     model: ollama:qwen3:1.7b

--- a/examples/v1/csv-enrichment/config.yaml
+++ b/examples/v1/csv-enrichment/config.yaml
@@ -30,4 +30,4 @@ steps:
 
   - name: report
     from: classified
-    write: ./enriched.csv
+    write: enriched.csv

--- a/examples/v1/inbox-triage/README.md
+++ b/examples/v1/inbox-triage/README.md
@@ -12,9 +12,9 @@ emails into `inbox/` and rerun.
 1. `emails` — `read: ./inbox/*.txt` → one row per file (`{path, name, content}`)
 2. `triage` — `forEach` email → SGR `{reasoning, subject, category, priority, sentiment, summary}`
 3. `board_rows` — **transform** drops the reasoning, keeping the scannable columns
-4. `board` — `write: ./board.csv` → the triage board
+4. `board` — `write: board.csv` → the triage board
 5. `drafts` — `forEach` triage row → `{subject, reply}` (drafted from the summary, not the raw email)
-6. `reply_digest` — `write: ./replies.md` → the suggested replies as a Markdown table
+6. `reply_digest` — `write: replies.md` → the suggested replies as a Markdown table
 
 ## Requirements
 
@@ -25,6 +25,6 @@ emails into `inbox/` and rerun.
 
 ```bash
 datamatic --config ./config.yaml --verbose
-cat ./board.csv
-cat ./replies.md
+cat ./dataset/board.csv
+cat ./dataset/replies.md
 ```

--- a/examples/v1/inbox-triage/README.md
+++ b/examples/v1/inbox-triage/README.md
@@ -9,7 +9,7 @@ emails into `inbox/` and rerun.
 
 ## Steps
 
-1. `emails` — `read: ./inbox/*.txt` → one row per file (`{path, name, content}`)
+1. `emails` — `read: inbox/*.txt` → one row per file (`{path, name, content}`)
 2. `triage` — `forEach` email → SGR `{reasoning, subject, category, priority, sentiment, summary}`
 3. `board_rows` — **transform** drops the reasoning, keeping the scannable columns
 4. `board` — `write: board.csv` → the triage board

--- a/examples/v1/inbox-triage/config.yaml
+++ b/examples/v1/inbox-triage/config.yaml
@@ -51,7 +51,7 @@ steps:
 
   - name: board
     from: board_rows
-    write: ./board.csv
+    write: board.csv
 
   - name: drafts
     model: ollama:qwen3:1.7b
@@ -79,4 +79,4 @@ steps:
 
   - name: reply_digest
     from: drafts
-    write: ./replies.md
+    write: replies.md

--- a/examples/v1/inbox-triage/config.yaml
+++ b/examples/v1/inbox-triage/config.yaml
@@ -5,7 +5,7 @@ version: 1.0
 # shape a scannable board → draft a suggested reply → write CSV + Markdown.
 steps:
   - name: emails
-    read: ./inbox/*.txt
+    read: inbox/*.txt
 
   - name: triage
     model: ollama:qwen3:1.7b

--- a/examples/v1/process-my-files/README.md
+++ b/examples/v1/process-my-files/README.md
@@ -8,12 +8,12 @@ becomes a row, and each is triaged into a structured record.
 
 ## Steps
 
-1. `tickets` — `read: ./docs/*.md` → one row per file: `{path, name, content}`
+1. `tickets` — `read: docs/*.md` → one row per file: `{path, name, content}`
 2. `triage` — `forEach` ticket → `{category, priority, summary}`
 
 Point `read` at your own path to process your data. Other forms:
-`read: ./data.csv` (one row per record), `read: ./seed.jsonl` (one row per line),
-`read: ./docs/` (a whole directory). Override detection with `format:`.
+`read: data.csv` (one row per record), `read: seed.jsonl` (one row per line),
+`read: docs/` (a whole directory). Override detection with `format:`.
 
 ## Requirements
 

--- a/examples/v1/process-my-files/config.yaml
+++ b/examples/v1/process-my-files/config.yaml
@@ -4,7 +4,7 @@ version: 1.0
 # a directory, a .csv, or a .jsonl and it becomes rows; here: one row per file.
 steps:
   - name: tickets
-    read: ./docs/*.md
+    read: docs/*.md
 
   - name: triage
     model: ollama:qwen3:1.7b

--- a/examples/v1/vision/README.md
+++ b/examples/v1/vision/README.md
@@ -10,7 +10,7 @@ accessibility.
 
 ## Steps
 
-1. `images` — `read: ./images/*.jpg` → one row per image: `{path, name, content}`
+1. `images` — `read: images/*.jpg` → one row per image: `{path, name, content}`
 2. `describe` — `forEach` image, `image: {{.item.path}}` attaches it → `{description, main_colors[], tags[]}`
 
 Point `read` at your own image folder to process your files.

--- a/examples/v1/vision/config.yaml
+++ b/examples/v1/vision/config.yaml
@@ -5,7 +5,7 @@ version: 1.0
 # as a vision image via `image: {{.item.path}}`.
 steps:
   - name: images
-    read: ./images/*.jpg
+    read: images/*.jpg
 
   - name: describe
     model: ollama:qwen2.5vl:3b

--- a/fs/folder.go
+++ b/fs/folder.go
@@ -4,36 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 const folderPerm = 0o755
 
-func CreateVersionedFolder(path string) error {
+// EnsureFolder makes sure the output folder exists, reusing it if it already
+// does. Runs are not archived into "<name>_vN" copies: each step overwrites its
+// own output file, so paths stay stable across reruns (deliverables included)
+// and an existing folder is what a future resume can build on.
+func EnsureFolder(path string) error {
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("path is not absolute %s", path)
-	}
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return createFolder(path)
-	} else if err != nil {
-		return fmt.Errorf("failed to stat folder %s: %w", path, err)
-	}
-
-	dir := filepath.Dir(path)
-	base := sanitizeFolderName(filepath.Base(path))
-
-	nextVersion, err := getNextFolderVersion(dir, base)
-	if err != nil {
-		return fmt.Errorf("failed to get next version for folder %s: %w", path, err)
-	}
-
-	versionedPath := filepath.Join(dir, fmt.Sprintf("%s_v%d", base, nextVersion))
-
-	if err := os.Rename(path, versionedPath); err != nil {
-		return fmt.Errorf("failed to rename folder from %s to %s: %w", path, versionedPath, err)
 	}
 
 	return createFolder(path)
@@ -44,56 +25,4 @@ func createFolder(path string) error {
 		return fmt.Errorf("failed to create folder %s: %w", path, err)
 	}
 	return nil
-}
-
-func getNextFolderVersion(dir, base string) (int, error) {
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read directory %s: %w", dir, err)
-	}
-
-	maxVersion := 0
-	re := regexp.MustCompile(fmt.Sprintf(`^%s_v(\d+)$`, regexp.QuoteMeta(base)))
-
-	for _, file := range files {
-		if file.IsDir() {
-			if version, err := parseVersion(re, file.Name()); err == nil {
-				if version > maxVersion {
-					maxVersion = version
-				}
-			}
-		}
-	}
-
-	return maxVersion + 1, nil
-}
-
-func parseVersion(re *regexp.Regexp, name string) (int, error) {
-	matches := re.FindStringSubmatch(name)
-	if len(matches) != 2 {
-		return 0, fmt.Errorf("folder name %s does not match version pattern", name)
-	}
-
-	version, err := strconv.Atoi(matches[1])
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse version number from folder name %s: %w", name, err)
-	}
-
-	return version, nil
-}
-
-func sanitizeFolderName(name string) string {
-	invalidChars := regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F. ]`)
-	sanitized := invalidChars.ReplaceAllString(name, "_")
-
-	consecutiveUnderscores := regexp.MustCompile(`_+`)
-	sanitized = consecutiveUnderscores.ReplaceAllString(sanitized, "_")
-
-	sanitized = strings.Trim(sanitized, "_")
-
-	if sanitized == "" {
-		return "_"
-	}
-
-	return sanitized
 }

--- a/fs/folder.go
+++ b/fs/folder.go
@@ -8,19 +8,16 @@ import (
 
 const folderPerm = 0o755
 
-// EnsureFolder makes sure the output folder exists, reusing it if it already
-// does. Runs are not archived into "<name>_vN" copies: each step overwrites its
-// own output file, so paths stay stable across reruns (deliverables included)
-// and an existing folder is what a future resume can build on.
+// EnsureFolder creates a folder for generated output if it does not exist yet,
+// and is a no-op when it does — reruns reuse the folder in place rather than
+// archiving it into a "<name>_vN" copy, so output paths stay stable. The path
+// must be absolute: every folder here is derived from the resolved output
+// folder, so a relative one means a caller skipped that resolution.
 func EnsureFolder(path string) error {
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("path is not absolute %s", path)
 	}
 
-	return createFolder(path)
-}
-
-func createFolder(path string) error {
 	if err := os.MkdirAll(path, folderPerm); err != nil {
 		return fmt.Errorf("failed to create folder %s: %w", path, err)
 	}

--- a/fs/folder_test.go
+++ b/fs/folder_test.go
@@ -10,17 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateFolder(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "test_folder")
-
-	err := createFolder(path)
-	assert.NoError(t, err, "Expected no error when creating folder")
-
-	_, err = os.Stat(path)
-	assert.False(t, os.IsNotExist(err), "Expected folder %s to be created, but it does not exist", path)
-}
-
 // TestEnsureFolder pins the rerun contract: the output folder is reused in
 // place, never rotated to a "_vN" copy. Steps overwrite their own files, so a
 // rerun keeps stable paths (deliverables included) and leaves room for resume.
@@ -46,7 +35,7 @@ func TestEnsureFolder_RejectsRelativePath(t *testing.T) {
 	assert.Error(t, EnsureFolder("relative/path"), "the output folder is resolved to an absolute path before use")
 }
 
-func TestCreateFolderNegative(t *testing.T) {
+func TestEnsureFolder_CreationFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	var pathToCreate string
 
@@ -63,7 +52,7 @@ func TestCreateFolderNegative(t *testing.T) {
 		defer os.Chmod(tmpDir, 0o755) //nolint:golint,errcheck
 	}
 
-	err := createFolder(pathToCreate)
+	err := EnsureFolder(pathToCreate)
 
 	assert.Error(t, err, "Expected error during folder creation")
 }

--- a/fs/folder_test.go
+++ b/fs/folder_test.go
@@ -3,11 +3,11 @@ package fs
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateFolder(t *testing.T) {
@@ -21,55 +21,29 @@ func TestCreateFolder(t *testing.T) {
 	assert.False(t, os.IsNotExist(err), "Expected folder %s to be created, but it does not exist", path)
 }
 
-func TestGetNextFolderVersion(t *testing.T) {
-	tmpDir := t.TempDir()
-	base := "test_folder"
-
-	_ = os.Mkdir(filepath.Join(tmpDir, "test_folder_v1"), folderPerm)
-	_ = os.Mkdir(filepath.Join(tmpDir, "test_folder_v2"), folderPerm)
-	_ = os.Mkdir(filepath.Join(tmpDir, "test_folder_v5"), folderPerm)
-	_ = os.Mkdir(filepath.Join(tmpDir, "test_folder_v19"), folderPerm)
-
-	nextVersion, err := getNextFolderVersion(tmpDir, base)
-	assert.NoError(t, err, "Expected no error when retrieving next folder version")
-
-	expectedVersion := 20
-	assert.Equal(t, expectedVersion, nextVersion, "Expected next version to be %d, got %d", expectedVersion, nextVersion)
-}
-
-func TestParseVersion(t *testing.T) {
-	re := regexp.MustCompile(`^test_folder_v(\d+)$`)
-
-	version, err := parseVersion(re, "test_folder_v3")
-	assert.NoError(t, err, "Expected no error for valid folder name")
-	assert.Equal(t, 3, version, "Expected version 3, got %d", version)
-
-	_, err = parseVersion(re, "test_folder")
-	assert.Error(t, err, "Expected error for folder without version")
-
-	_, err = parseVersion(re, "test_folder_vx")
-	assert.Error(t, err, "Expected error for folder with invalid version format")
-}
-
-func TestCreateVersionedFolder(t *testing.T) {
+// TestEnsureFolder pins the rerun contract: the output folder is reused in
+// place, never rotated to a "_vN" copy. Steps overwrite their own files, so a
+// rerun keeps stable paths (deliverables included) and leaves room for resume.
+func TestEnsureFolder(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "test_folder")
 
-	err := CreateVersionedFolder(path)
-	assert.NoError(t, err, "Expected no error on first call to CreateVersionedFolder")
+	require.NoError(t, EnsureFolder(path), "first call creates the folder")
+	assert.DirExists(t, path)
 
-	_, err = os.Stat(path)
-	assert.False(t, os.IsNotExist(err), "Expected folder %s to be created, but it does not exist", path)
+	// a previous run left a file behind
+	leftover := filepath.Join(path, "step.jsonl")
+	require.NoError(t, os.WriteFile(leftover, []byte("{}\n"), 0o644))
 
-	err = CreateVersionedFolder(path)
-	assert.NoError(t, err, "Expected no error on second call to CreateVersionedFolder")
+	require.NoError(t, EnsureFolder(path), "second call reuses the folder")
 
-	versionedPath := filepath.Join(tmpDir, "test_folder_v1")
-	_, err = os.Stat(versionedPath)
-	assert.False(t, os.IsNotExist(err), "Expected versioned folder %s to be created, but it does not exist", versionedPath)
+	assert.DirExists(t, path)
+	assert.NoDirExists(t, filepath.Join(tmpDir, "test_folder_v1"), "must not rotate the folder to a versioned copy")
+	assert.FileExists(t, leftover, "reusing the folder must not wipe it; steps overwrite their own files")
+}
 
-	_, err = os.Stat(path)
-	assert.False(t, os.IsNotExist(err), "Expected new folder %s to be created, but it does not exist", path)
+func TestEnsureFolder_RejectsRelativePath(t *testing.T) {
+	assert.Error(t, EnsureFolder("relative/path"), "the output folder is resolved to an absolute path before use")
 }
 
 func TestCreateFolderNegative(t *testing.T) {
@@ -92,35 +66,4 @@ func TestCreateFolderNegative(t *testing.T) {
 	err := createFolder(pathToCreate)
 
 	assert.Error(t, err, "Expected error during folder creation")
-}
-
-func TestGetNextFolderVersionNoFolders(t *testing.T) {
-	tmpDir := t.TempDir()
-	base := "test_folder"
-
-	nextVersion, err := getNextFolderVersion(tmpDir, base)
-	assert.NoError(t, err, "Expected no error when retrieving version for an empty directory")
-	assert.Equal(t, 1, nextVersion, "Expected version to start at 1 for empty directory")
-}
-
-func TestSanitizeFolderName(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected string
-	}{
-		{"valid_name", "valid_name"},
-		{"name with spaces", "name_with_spaces"},
-		{"name/with/slash", "name_with_slash"},
-		{">invalid<chars", "invalid_chars"}, // Leading invalid character should add "_"
-		{"   trailing spaces  ", "trailing_spaces"},
-		{"..trailing.dots..", "trailing_dots"}, // Dots replaced
-		{"special|<>:*?chars", "special_chars"},
-		{"multiple___underscores", "multiple_underscores"},
-		{"", "_"}, // Empty name should return "_"
-	}
-
-	for _, test := range tests {
-		result := sanitizeFolderName(test.name)
-		assert.Equal(t, test.expected, result, "Expected sanitized name to be %s, got %s", test.expected, result)
-	}
 }

--- a/jsonl/jsonl.go
+++ b/jsonl/jsonl.go
@@ -37,14 +37,12 @@ func (w *Writer) WriteJSON(v interface{}) error {
 		return fmt.Errorf("failed to marshal value: %w", err)
 	}
 
-	log.Debug().Msgf("writing jsonl line: %s", string(jsonData))
+	log.Debug().Bytes("line", jsonData).Msg("writing jsonl line")
 
-	if _, err := w.file.Write(jsonData); err != nil {
+	// one write per row: the file is unbuffered, so appending the newline here
+	// halves the syscalls versus a separate WriteString
+	if _, err := w.file.Write(append(jsonData, '\n')); err != nil {
 		return fmt.Errorf("failed to write json data to file: %w", err)
-	}
-
-	if _, err := w.file.WriteString("\n"); err != nil {
-		return fmt.Errorf("failed to write newline after json data: %w", err)
 	}
 
 	return nil

--- a/jsonl/jsonl.go
+++ b/jsonl/jsonl.go
@@ -12,8 +12,11 @@ type Writer struct {
 	file *os.File
 }
 
+// NewWriter opens a step's output file for writing, truncating it: a step
+// materializes all of its rows in one pass, so the file always holds exactly
+// the rows of the run that produced it (a rerun replaces, never appends).
 func NewWriter(path string) (*Writer, error) {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}

--- a/jsonl/jsonl_test.go
+++ b/jsonl/jsonl_test.go
@@ -23,6 +23,25 @@ func TestNewWriter(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestNewWriter_TruncatesExistingFile pins the contract a rerun depends on: a
+// step's output file holds only the rows of the run that produced it. Appending
+// would silently stack a new run's rows on top of the previous one's.
+func TestNewWriter_TruncatesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "step.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(`{"stale":"previous run"}`+"\n"), 0o644))
+
+	writer, err := NewWriter(path)
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteJSON(map[string]string{"fresh": "current run"}))
+	require.NoError(t, writer.Close())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"fresh":"current run"}`+"\n", string(content),
+		"reopening a step's output must replace the previous run's rows, not append to them")
+}
+
 func TestWriteLine(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test*.jsonl")
 	assert.NoError(t, err)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -23,7 +23,7 @@ func NewRunner(cfg *config.Config) *Runner {
 func (r *Runner) PrepareOutputDirectory() error {
 	log.Debug().Msgf("Preparing root output folder: %s", r.cfg.OutputFolder)
 
-	if err := fs.CreateVersionedFolder(r.cfg.OutputFolder); err != nil {
+	if err := fs.EnsureFolder(r.cfg.OutputFolder); err != nil {
 		return fmt.Errorf("failed to prepare output directory: %w", err)
 	}
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -200,14 +200,7 @@ func TestRun_RerunReusesOutputFolder(t *testing.T) {
 	run()
 	run()
 
-	siblings, err := os.ReadDir(filepath.Dir(outputFolder))
-	require.NoError(t, err)
-	for _, entry := range siblings {
-		assert.NotContains(t, entry.Name(), filepath.Base(outputFolder)+"_v",
-			"a rerun must not archive the output folder into a versioned copy")
-	}
-
-	data, err := os.ReadFile(filepath.Join(outputFolder, "gen.jsonl"))
-	require.NoError(t, err)
-	assert.Equal(t, 2, strings.Count(string(data), "\n"), "the file must hold one run's rows, not both runs appended")
+	assert.NoDirExists(t, outputFolder+"_v1", "a rerun must not archive the output folder into a versioned copy")
+	assert.Len(t, readOutputLines(t, filepath.Join(outputFolder, "gen.jsonl")), 2,
+		"the file must hold one run's rows, not both runs appended")
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -174,3 +174,40 @@ func TestRun_ReadEnrichWritePipeline(t *testing.T) {
 	assert.Contains(t, got, "tech")
 	assert.Contains(t, got, "finance")
 }
+
+// TestRun_RerunReusesOutputFolder is the end-to-end rerun contract: running the
+// same config twice reuses the output folder (no "_vN" archive copies) and each
+// step's file holds one run's rows, not both runs stacked.
+func TestRun_RerunReusesOutputFolder(t *testing.T) {
+	outputFolder := t.TempDir()
+
+	run := func() {
+		srv := llmtest.NewServer(t, `{"title":"a"}`, `{"title":"b"}`)
+		cfg := config.NewConfig()
+		cfg.OutputFolder = outputFolder
+		cfg.Version = "1.0"
+		cfg.Steps = []config.Step{{
+			Name: "gen", Model: "ollama:test-model", Count: 2,
+			Prompt:        "Give a title",
+			JSONSchemaRaw: `{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}`,
+			ModelConfig:   config.ModelConfig{BaseURL: srv.URL},
+		}}
+		require.NoError(t, utils.PreprocessConfig(cfg))
+		require.NoError(t, cfg.Validate())
+		require.NoError(t, runner.NewRunner(cfg).Run(context.Background()))
+	}
+
+	run()
+	run()
+
+	siblings, err := os.ReadDir(filepath.Dir(outputFolder))
+	require.NoError(t, err)
+	for _, entry := range siblings {
+		assert.NotContains(t, entry.Name(), filepath.Base(outputFolder)+"_v",
+			"a rerun must not archive the output folder into a versioned copy")
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputFolder, "gen.jsonl"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, strings.Count(string(data), "\n"), "the file must hold one run's rows, not both runs appended")
+}

--- a/step/write_step.go
+++ b/step/write_step.go
@@ -2,12 +2,12 @@ package step
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
+	"github.com/mirpo/datamatic/jsonl"
 	"github.com/rs/zerolog/log"
 )
 
@@ -76,16 +76,17 @@ func asObjects(rows []interface{}) ([]map[string]interface{}, error) {
 	return objs, nil
 }
 
+// writeJSONL reuses the shared JSONL writer, so the deliverable's line format
+// stays defined in one place (the writer truncates: a fresh file each run).
 func writeJSONL(path string, rows []interface{}) error {
-	file, err := os.Create(path) // truncate: a fresh deliverable each run
+	writer, err := jsonl.NewWriter(path)
 	if err != nil {
 		return fmt.Errorf("failed to create '%s': %w", path, err)
 	}
-	defer file.Close()
+	defer writer.Close()
 
-	enc := json.NewEncoder(file) // Encode writes one compact JSON value + newline
 	for _, row := range rows {
-		if err := enc.Encode(row); err != nil {
+		if err := writer.WriteJSON(row); err != nil {
 			return fmt.Errorf("failed to write row: %w", err)
 		}
 	}

--- a/step/write_step.go
+++ b/step/write_step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
@@ -30,6 +31,12 @@ func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Ste
 
 	rows, err := collectRows(ctx, *src, file)
 	if err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
+	}
+
+	// the deliverable may nest (e.g. write: reports/board.csv), and the output
+	// folder starts out fresh, so its parent won't exist yet
+	if err := fs.EnsureFolder(filepath.Dir(step.Write)); err != nil {
 		return fmt.Errorf("step '%s': %w", step.Name, err)
 	}
 

--- a/step/write_step.go
+++ b/step/write_step.go
@@ -23,6 +23,13 @@ func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Ste
 		return fmt.Errorf("'from' references unknown step '%s'", step.From)
 	}
 
+	// the deliverable may nest (e.g. write: reports/board.csv), and the output
+	// folder starts out fresh, so its parent won't exist yet. Done before
+	// reading the source so an unwritable destination fails immediately.
+	if err := fs.EnsureFolder(filepath.Dir(step.Write)); err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
+	}
+
 	file, err := os.Open(src.OutputFilename)
 	if err != nil {
 		return fmt.Errorf("step '%s': failed to open source '%s': %w", step.Name, src.OutputFilename, err)
@@ -31,12 +38,6 @@ func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Ste
 
 	rows, err := collectRows(ctx, *src, file)
 	if err != nil {
-		return fmt.Errorf("step '%s': %w", step.Name, err)
-	}
-
-	// the deliverable may nest (e.g. write: reports/board.csv), and the output
-	// folder starts out fresh, so its parent won't exist yet
-	if err := fs.EnsureFolder(filepath.Dir(step.Write)); err != nil {
 		return fmt.Errorf("step '%s': %w", step.Name, err)
 	}
 

--- a/step/write_step_test.go
+++ b/step/write_step_test.go
@@ -55,6 +55,26 @@ func TestWriteStepRun_JSONLPassthrough(t *testing.T) {
 	assert.Equal(t, `{"a":1}`+"\n"+`{"a":2}`+"\n", string(data))
 }
 
+// TestWriteStepRun_CreatesParentDir covers a nested deliverable path: the
+// output folder is created fresh, so a subdirectory in the write path won't
+// exist yet and the step has to make it.
+func TestWriteStepRun_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.jsonl")
+	require.NoError(t, os.WriteFile(srcPath, []byte(`{"a":1}`+"\n"), 0o644))
+
+	cfg := config.NewConfig()
+	cfg.Steps = []config.Step{{Name: "data", Type: config.TransformStepType, OutputFilename: srcPath}}
+	out := filepath.Join(dir, "reports", "2026", "out.csv")
+	step := config.Step{
+		Name: "report", Type: config.WriteStepType, From: "data",
+		Write: out, Format: config.WriteFormatCSV, OutputFilename: out,
+	}
+
+	require.NoError(t, (&WriteStep{}).Run(context.Background(), cfg, step, dir))
+	assert.FileExists(t, out)
+}
+
 func TestWriteStepRun_UnknownSourceFails(t *testing.T) {
 	cfg := config.NewConfig()
 	step := config.Step{Name: "report", Type: config.WriteStepType, From: "ghost", Write: "/tmp/x.csv", Format: config.WriteFormatCSV, OutputFilename: "/tmp/x.csv"}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -367,20 +367,24 @@ func getFullOutputPath(step config.Step, outputFolder string) (string, error) {
 // directory, so a workflow's data files travel with it and it runs from any
 // working directory. Absolute paths are left unchanged.
 func resolveDataPath(configFile, path string) string {
-	if path == "" || filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Join(filepath.Dir(configFile), path)
+	return joinIfRelative(filepath.Dir(configFile), path)
 }
 
 // resolveOutputPath puts a relative generated path inside the output folder, so
 // everything a run produces lands in one place. Absolute paths are left
 // unchanged, which is how a deliverable is published outside that folder.
 func resolveOutputPath(outputFolder, path string) string {
+	return joinIfRelative(outputFolder, path)
+}
+
+// joinIfRelative is the shared rule behind both resolvers: an absolute path is
+// already the answer, and an empty one means "not set" — only a relative path
+// is anchored to a base.
+func joinIfRelative(base, path string) string {
 	if path == "" || filepath.IsAbs(path) {
 		return path
 	}
-	return filepath.Join(outputFolder, path)
+	return filepath.Join(base, path)
 }
 
 // resolveReadFormat validates an explicit read `format` or infers it from the
@@ -538,18 +542,16 @@ func setRootOutputFolder(cfg *config.Config) error {
 	return nil
 }
 
-// setWorkDir sets and normalizes the working directory for shell steps
+// setWorkDir sets and normalizes the working directory for shell steps. It
+// anchors like any other generated path (see resolveOutputPath), defaulting to
+// the output folder itself.
 func setWorkDir(step *config.Step, outputFolder string) error {
 	if step.WorkDir == "" {
 		step.WorkDir = outputFolder
 		return nil
 	}
 
-	if !filepath.IsAbs(step.WorkDir) {
-		step.WorkDir = filepath.Join(outputFolder, step.WorkDir)
-	}
-
-	absPath, err := filepath.Abs(step.WorkDir)
+	absPath, err := filepath.Abs(resolveOutputPath(outputFolder, step.WorkDir))
 	if err != nil {
 		return fmt.Errorf("invalid workDir path: %w", err)
 	}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -507,14 +507,31 @@ func isValidName(name string) error {
 	return nil
 }
 
+// defaultOutputFolder is where a run writes when nothing else says otherwise:
+// next to the config, so the same workflow lands in the same place no matter
+// which directory it was launched from.
+const defaultOutputFolder = "dataset"
+
+// setRootOutputFolder resolves the one folder every step writes into. In order
+// of precedence: the --output flag (relative to the working directory, because
+// that is where it was typed), the `output:` key (relative to the config, so it
+// travels with the workflow), a folder assigned programmatically, and finally
+// the default next to the config.
 func setRootOutputFolder(cfg *config.Config) error {
-	if len(cfg.OutputFolder) == 0 {
-		return errors.New("output folder is required")
+	folder := cfg.OutputFolder // programmatic callers may set this directly
+
+	switch {
+	case cfg.OutputFlag != "":
+		folder = cfg.OutputFlag
+	case cfg.Output != "":
+		folder = resolveDataPath(cfg.ConfigFile, cfg.Output)
+	case folder == "":
+		folder = resolveDataPath(cfg.ConfigFile, defaultOutputFolder)
 	}
 
-	absOutputFolder, err := filepath.Abs(cfg.OutputFolder)
+	absOutputFolder, err := filepath.Abs(folder)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path for output folder '%s': %w", cfg.OutputFolder, err)
+		return fmt.Errorf("failed to get absolute path for output folder '%s': %w", folder, err)
 	}
 
 	cfg.OutputFolder = absOutputFolder

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -221,8 +221,9 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Write steps: terminal export of a source step's rows to a file
-		// (path resolves relative to the config file's dir — the deliverable)
+		// Write steps: terminal export of a source step's rows to a file. The
+		// deliverable is generated output, so a relative path joins the output
+		// folder (an absolute path publishes outside it).
 		if step.Type == config.WriteStepType {
 			if step.From == "" {
 				return fmt.Errorf("step '%s': 'from' is required for write steps", step.Name)
@@ -230,7 +231,7 @@ func PreprocessConfig(cfg *config.Config) error {
 			if err := requireEarlierStep(stepNames, "from", step.From); err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
 			}
-			step.Write = resolveDataPath(cfg.ConfigFile, step.Write)
+			step.Write = resolveOutputPath(cfg.OutputFolder, step.Write)
 			format, err := resolveWriteFormat(step)
 			if err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
@@ -362,14 +363,24 @@ func getFullOutputPath(step config.Step, outputFolder string) (string, error) {
 	return filepath.Clean(fullPath), nil
 }
 
-// resolveDataPath makes a relative read/write path relative to the config
-// file's directory, so a workflow's data files travel with it and it runs from
-// any working directory. Absolute paths are left unchanged.
+// resolveDataPath makes a relative input path relative to the config file's
+// directory, so a workflow's data files travel with it and it runs from any
+// working directory. Absolute paths are left unchanged.
 func resolveDataPath(configFile, path string) string {
 	if path == "" || filepath.IsAbs(path) {
 		return path
 	}
 	return filepath.Join(filepath.Dir(configFile), path)
+}
+
+// resolveOutputPath puts a relative generated path inside the output folder, so
+// everything a run produces lands in one place. Absolute paths are left
+// unchanged, which is how a deliverable is published outside that folder.
+func resolveOutputPath(outputFolder, path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(outputFolder, path)
 }
 
 // resolveReadFormat validates an explicit read `format` or infers it from the

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -705,6 +705,73 @@ func TestPreprocessConfig_DataPathsResolveToConfigDir(t *testing.T) {
 	assert.Equal(t, absIn, cfg.Steps[2].Read, "absolute read unchanged")
 }
 
+// TestPreprocessConfig_OutputFolderResolution pins where generated output goes.
+// A path written in the config travels with the config; a path typed on the
+// command line is relative to where the command was typed.
+func TestPreprocessConfig_OutputFolderResolution(t *testing.T) {
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, "flow.yaml")
+
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.ConfigFile = configFile
+		cfg.Steps = []config.Step{{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 1}}
+		return cfg
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	t.Run("default sits next to the config, not in the working directory", func(t *testing.T) {
+		cfg := base()
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, filepath.Join(configDir, "dataset"), cfg.OutputFolder)
+	})
+
+	t.Run("output: in the config resolves against the config dir", func(t *testing.T) {
+		cfg := base()
+		cfg.Output = "results"
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, filepath.Join(configDir, "results"), cfg.OutputFolder)
+	})
+
+	t.Run("--output flag resolves against the working directory", func(t *testing.T) {
+		cfg := base()
+		cfg.OutputFlag = "today"
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, filepath.Join(cwd, "today"), cfg.OutputFolder)
+	})
+
+	t.Run("--output flag wins over output: in the config", func(t *testing.T) {
+		cfg := base()
+		cfg.Output = "results"
+		cfg.OutputFlag = "today"
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, filepath.Join(cwd, "today"), cfg.OutputFolder)
+	})
+
+	t.Run("absolute paths are used as-is", func(t *testing.T) {
+		abs := filepath.Join(t.TempDir(), "elsewhere")
+
+		cfg := base()
+		cfg.Output = abs
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, abs, cfg.OutputFolder)
+
+		cfg = base()
+		cfg.OutputFlag = abs
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, abs, cfg.OutputFolder)
+	})
+
+	t.Run("an explicitly assigned OutputFolder is honored", func(t *testing.T) {
+		explicit := t.TempDir()
+		cfg := base()
+		cfg.OutputFolder = explicit
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, explicit, cfg.OutputFolder)
+	})
+}
+
 // TestPreprocessConfig_WriteDeliverablesLandInOutputFolder pins the split: an
 // input path travels with the config, everything generated goes to the one
 // output folder, and an absolute path is an escape hatch from both.

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -701,6 +701,35 @@ func TestPreprocessConfig_DataPathsResolveToConfigDir(t *testing.T) {
 	require.NoError(t, PreprocessConfig(cfg))
 
 	assert.Equal(t, filepath.Join("some", "dir", "data", "*.md"), cfg.Steps[0].Read, "relative read → config dir")
-	assert.Equal(t, filepath.Join("some", "dir", "results.csv"), cfg.Steps[1].Write, "relative write → config dir")
+	assert.Equal(t, filepath.Join(cfg.OutputFolder, "results.csv"), cfg.Steps[1].Write, "relative write → output folder")
 	assert.Equal(t, absIn, cfg.Steps[2].Read, "absolute read unchanged")
+}
+
+// TestPreprocessConfig_WriteDeliverablesLandInOutputFolder pins the split: an
+// input path travels with the config, everything generated goes to the one
+// output folder, and an absolute path is an escape hatch from both.
+func TestPreprocessConfig_WriteDeliverablesLandInOutputFolder(t *testing.T) {
+	absOut := filepath.Join(t.TempDir(), "published.csv")
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = t.TempDir()
+	cfg.ConfigFile = filepath.Join("some", "dir", "config.yaml")
+	cfg.Steps = []config.Step{
+		{Name: "in", Read: "./data/*.md"},
+		{Name: "plain", From: "in", Write: "report.csv"},
+		{Name: "nested", From: "in", Write: "./sub/report.md"},
+		{Name: "absolute", From: "in", Write: absOut},
+	}
+
+	require.NoError(t, PreprocessConfig(cfg))
+
+	assert.Equal(t, filepath.Join(cfg.OutputFolder, "report.csv"), cfg.Steps[1].Write)
+	assert.Equal(t, filepath.Join(cfg.OutputFolder, "sub", "report.md"), cfg.Steps[2].Write,
+		"a nested relative path stays nested, under the output folder")
+	assert.Equal(t, absOut, cfg.Steps[3].Write, "absolute write is used as-is")
+
+	for i := 1; i <= 3; i++ {
+		assert.Equal(t, cfg.Steps[i].Write, cfg.Steps[i].OutputFilename,
+			"a write step's OutputFilename is its deliverable")
+	}
 }

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -712,64 +712,41 @@ func TestPreprocessConfig_OutputFolderResolution(t *testing.T) {
 	configDir := t.TempDir()
 	configFile := filepath.Join(configDir, "flow.yaml")
 
-	base := func() *config.Config {
-		cfg := config.NewConfig()
-		cfg.ConfigFile = configFile
-		cfg.Steps = []config.Step{{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 1}}
-		return cfg
-	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
+	abs := filepath.Join(t.TempDir(), "elsewhere")
+	preset := t.TempDir()
 
-	t.Run("default sits next to the config, not in the working directory", func(t *testing.T) {
-		cfg := base()
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, filepath.Join(configDir, "dataset"), cfg.OutputFolder)
-	})
+	tests := []struct {
+		name       string
+		output     string // output: in the config
+		outputFlag string // --output
+		preset     string // assigned programmatically before preprocessing
+		want       string
+	}{
+		{
+			name: "default sits next to the config, not in the working directory",
+			want: filepath.Join(configDir, defaultOutputFolder),
+		},
+		{name: "output: resolves against the config dir", output: "results", want: filepath.Join(configDir, "results")},
+		{name: "--output resolves against the working directory", outputFlag: "today", want: filepath.Join(cwd, "today")},
+		{name: "--output wins over output:", output: "results", outputFlag: "today", want: filepath.Join(cwd, "today")},
+		{name: "absolute output: is used as-is", output: abs, want: abs},
+		{name: "absolute --output is used as-is", outputFlag: abs, want: abs},
+		{name: "a programmatically assigned folder is honored", preset: preset, want: preset},
+	}
 
-	t.Run("output: in the config resolves against the config dir", func(t *testing.T) {
-		cfg := base()
-		cfg.Output = "results"
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, filepath.Join(configDir, "results"), cfg.OutputFolder)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			cfg.ConfigFile = configFile
+			cfg.Steps = []config.Step{{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 1}}
+			cfg.Output, cfg.OutputFlag, cfg.OutputFolder = tc.output, tc.outputFlag, tc.preset
 
-	t.Run("--output flag resolves against the working directory", func(t *testing.T) {
-		cfg := base()
-		cfg.OutputFlag = "today"
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, filepath.Join(cwd, "today"), cfg.OutputFolder)
-	})
-
-	t.Run("--output flag wins over output: in the config", func(t *testing.T) {
-		cfg := base()
-		cfg.Output = "results"
-		cfg.OutputFlag = "today"
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, filepath.Join(cwd, "today"), cfg.OutputFolder)
-	})
-
-	t.Run("absolute paths are used as-is", func(t *testing.T) {
-		abs := filepath.Join(t.TempDir(), "elsewhere")
-
-		cfg := base()
-		cfg.Output = abs
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, abs, cfg.OutputFolder)
-
-		cfg = base()
-		cfg.OutputFlag = abs
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, abs, cfg.OutputFolder)
-	})
-
-	t.Run("an explicitly assigned OutputFolder is honored", func(t *testing.T) {
-		explicit := t.TempDir()
-		cfg := base()
-		cfg.OutputFolder = explicit
-		require.NoError(t, PreprocessConfig(cfg))
-		assert.Equal(t, explicit, cfg.OutputFolder)
-	})
+			require.NoError(t, PreprocessConfig(cfg))
+			assert.Equal(t, tc.want, cfg.OutputFolder)
+		})
+	}
 }
 
 // TestPreprocessConfig_WriteDeliverablesLandInOutputFolder pins the split: an


### PR DESCRIPTION
## Summary
Gives datamatic one coherent answer to "where do files come from, and where do they go", and removes the surprising `dataset` → `dataset_v1` renaming.

## The model

| Path | Relative to | Absolute |
| --- | --- | --- |
| `read:` (input) | the **config file's directory** — a workflow runs from any working directory | as-is |
| `write:` (deliverable) | the **output folder** | as-is — this is how you publish outside it |
| intermediate JSONL | the **output folder** (always) | — |
| `--output` (flag) | the **working directory** — that is where it was typed | as-is |
| `output:` (config key) | the **config file's directory** | as-is |

Default output folder: `dataset` **next to the config file**. Precedence: `--output` > `output:` > default.

## Why remove the versioning
Every run renamed an existing output folder to `<name>_vN` and started from an empty one. That:
- **made resume impossible by construction** (the next roadmap block) — each run began with nothing to resume from;
- **moved deliverables to a new path every run** (`report.csv` → `dataset_v3/report.csv`), useless for scripts, CI artifact paths, or just opening the file;
- grew without bound, with no retention and no way to opt out.

The folder is now reused in place and steps overwrite their own files. Explicit run history is still available: `--output runs/$(date +%F-%H%M)`.

⚠️ **The rotation was load-bearing:** `jsonl.NewWriter` opened with `O_APPEND`, which was only safe *because* the folder was always recreated empty. The first commit makes step output files truncate — without it, removing rotation would have silently appended one run's rows onto the previous run's. That commit also drops the write step's hand-rolled JSONL encoder in favour of the shared writer.

## Commits
1. `fix:` truncate step output files instead of appending
2. `feat!:` reuse the output folder instead of rotating it to `_vN`
3. `feat!:` write deliverables land in the output folder (write steps now create their parent directory, since a nested path points into a fresh folder)
4. `docs:` drop the `./` prefix from config paths — nothing in a config resolves against the working directory, so `./` was misleading; it stays meaningful on the command line, where `--output ./today` really is CWD-relative
5. `feat:` resolve the output folder next to the config by default (+ `output:` key)
6. `ci:` point the smoke check at the default output folder

## Verification
- Full `go test ./...` + `golangci-lint` green; new tests cover truncation, folder reuse (incl. an end-to-end double run), deliverable placement, nested deliverable paths, and all of the precedence rules.
- Live-verified on Ollama from a foreign working directory: default lands next to the config (nothing in CWD), `--output ./today` lands in CWD, `output:` lands next to the config, and a second run leaves no `_v1` and does not double the rows.
- The CI smoke step was reproduced locally against the new default.

## Breaking
Deliverable and output-folder locations change (no users yet, no compatibility shims). `dataset*` is already gitignored, so per-workflow output folders stay out of git.