### PR TITLE
feat: per-row file output — write a folder of documents, not just a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,32 @@ steps:
 - **`write:`** exports a step's rows to a file, format inferred from the extension: `.csv`, `.json` (array), `.md` (table), or `.jsonl`. It's terminal and doesn't change the intermediate JSONL that other steps read.
 - **`image:`** on a prompt step attaches a file as a vision image, e.g. `image: "{{.item.path}}"` after `read`-ing a folder of images.
 
+#### One file, or one file per row
+
+A write step's source picks its mode. `from:` writes **one file** with every row — a dataset or report. `forEach:` writes **one file per row** — a folder of documents:
+
+```yaml
+  - name: reply_digest
+    from: drafts                          # → one replies.md table of all drafts
+    write: replies.md
+
+  - name: reply_files
+    forEach: drafts                       # → one file per draft
+    write: replies/{{.item.subject}}.md   # path is a template, rendered per row
+    content: "{{.item.reply}}"            # body is raw text, not JSON
+```
+
+- The path template may nest (`write: out/{{.item.kind}}/{{.item.id}}.md`); missing directories are created.
+- **`content:`** is the file body as raw text — that is what makes the output a document rather than a record. Omit it and the row is serialized by extension instead (`.json`, `.csv`, …), one row per file.
+- Values interpolated into the path are made filename-safe, so a `/` or `:` inside your data can't redirect the file — only slashes you write in the template create directories. A name that renders empty falls back to the row number, and two rows producing the same name get numbered (`-2`) instead of overwriting each other.
+
 **Where paths point.** Inputs travel with the workflow; everything generated lands in the output folder:
 
 | Path | Relative to | Absolute |
 | --- | --- | --- |
 | `read:` (input) | the **config file's directory** — so a workflow runs from any working directory | used as-is |
 | `write:` (deliverable) | the **output folder** | used as-is — this is how you publish outside it |
+| `write:` per-row template | the **output folder**, after rendering | used as-is |
 | intermediate JSONL | the **output folder** | — |
 | `--output` (flag) | the **working directory** | used as-is |
 

--- a/config/config.go
+++ b/config/config.go
@@ -89,7 +89,8 @@ type Step struct {
 	Run            string      `yaml:"run"`
 	JQ             string      `yaml:"jq"`           // transform steps: jq program
 	Read           string      `yaml:"read"`         // read steps: file/glob/dir to load as rows
-	Write          string      `yaml:"write"`        // write steps: file path to export the source rows to
+	Write          string      `yaml:"write"`        // write steps: file path to export the source rows to (a per-row template when used with forEach)
+	Content        string      `yaml:"content"`      // per-row write steps: template for the file body, written as raw text
 	Format         string      `yaml:"format"`       // read: "files"|"csv"|"jsonl"; write: "csv"|"json"|"md"|"jsonl" (default: by extension)
 	From           string      `yaml:"from"`         // transform/write steps: source step name
 	Limit          int         `yaml:"limit"`        // transform steps: cap output rows (0 = no cap)

--- a/examples/v1/README.md
+++ b/examples/v1/README.md
@@ -7,7 +7,7 @@ Each folder is a self-contained `config.yaml` + `README.md`. New to datamatic? R
 | [basics](./basics) | text generation, JSON schema | Ollama |
 | [process-my-files](./process-my-files) | `read` your own local files (glob/dir/CSV/JSONL) → rows | Ollama |
 | [csv-enrichment](./csv-enrichment) | `read` CSV → enrich with LLM → `write` CSV (the full office loop) | Ollama |
-| [inbox-triage](./inbox-triage) | `read` folder of emails → SGR triage → draft replies → `write` CSV + Markdown | Ollama |
+| [inbox-triage](./inbox-triage) | `read` folder of emails → SGR triage → draft replies → `write` a board (CSV) + one file per reply | Ollama |
 | [linked-steps](./linked-steps) | step chaining, native template values (`if`/`range`/`len`) | Ollama |
 | [structured-extraction](./structured-extraction) | nested schema, both schema formats (YAML / JSON-string), native templates | Ollama |
 | [dataset-pipeline](./dataset-pipeline) | transform fan-out, fan-in (`collect`, `$parent`), rating pipeline | Ollama |

--- a/examples/v1/inbox-triage/README.md
+++ b/examples/v1/inbox-triage/README.md
@@ -2,10 +2,10 @@
 
 A real support-desk loop, no shell: **read a folder of incoming emails →
 classify each with schema-guided reasoning → draft a suggested reply → write a
-triage board (CSV) and a drafts digest (Markdown)**. Drop your own `.txt`
-emails into `inbox/` and rerun.
+triage board (CSV), a drafts digest (Markdown), and one editable reply file per
+ticket**. Drop your own `.txt` emails into `inbox/` and rerun.
 
-**Features:** `read` (folder of files) · `SGR` · `forEach` · `transform` · `write` (csv + md)
+**Features:** `read` (folder of files) · `SGR` · `forEach` · `transform` · `write` (aggregate + per-row)
 
 ## Steps
 
@@ -14,7 +14,11 @@ emails into `inbox/` and rerun.
 3. `board_rows` — **transform** drops the reasoning, keeping the scannable columns
 4. `board` — `write: board.csv` → the triage board
 5. `drafts` — `forEach` triage row → `{subject, reply}` (drafted from the summary, not the raw email)
-6. `reply_digest` — `write: replies.md` → the suggested replies as a Markdown table
+6. `reply_digest` — `write: replies.md` → all drafts as one Markdown table (aggregate mode)
+7. `reply_files` — `forEach` draft → `replies/<subject>.md`, one file per ticket whose body is the reply itself (per-row mode)
+
+Steps 6 and 7 show the two write modes side by side: `from:` for one file with
+every row, `forEach:` + `content:` for a folder of documents.
 
 ## Requirements
 
@@ -27,4 +31,5 @@ emails into `inbox/` and rerun.
 datamatic --config ./config.yaml --verbose
 cat ./dataset/board.csv
 cat ./dataset/replies.md
+ls ./dataset/replies/
 ```

--- a/examples/v1/inbox-triage/config.yaml
+++ b/examples/v1/inbox-triage/config.yaml
@@ -82,8 +82,11 @@ steps:
     from: drafts
     write: replies.md
 
-  # per-row: one editable file per ticket, named after its subject
+  # per-row: one editable file per ticket, named after its subject.
+  # content is written verbatim — the block scalar adds the trailing newline a
+  # text file should end with (quote it instead to control the bytes exactly)
   - name: reply_files
     forEach: drafts
     write: replies/{{.item.subject}}.md
-    content: "{{.item.reply}}"
+    content: |
+      {{.item.reply}}

--- a/examples/v1/inbox-triage/config.yaml
+++ b/examples/v1/inbox-triage/config.yaml
@@ -77,6 +77,13 @@ steps:
       required: [subject, reply]
       additionalProperties: false
 
+  # aggregate: one Markdown table of every draft, to skim
   - name: reply_digest
     from: drafts
     write: replies.md
+
+  # per-row: one editable file per ticket, named after its subject
+  - name: reply_files
+    forEach: drafts
+    write: replies/{{.item.subject}}.md
+    content: "{{.item.reply}}"

--- a/fs/write.go
+++ b/fs/write.go
@@ -105,6 +105,24 @@ func WriteMarkdownTable(path string, rows []map[string]interface{}) error {
 	return nil
 }
 
+// SanitizeFilename makes a string safe to use as one path segment, for file
+// names built from row data. Both slash kinds are replaced regardless of
+// platform, so a name written on one OS cannot redirect the file on another.
+// Returns "" when nothing usable remains, leaving the fallback to the caller.
+func SanitizeFilename(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == ':' || r < 0x20 {
+			return '_'
+		}
+		return r
+	}, strings.TrimSpace(s))
+
+	if strings.Trim(s, "_. ") == "" {
+		return ""
+	}
+	return s
+}
+
 func mdEscape(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	return strings.ReplaceAll(s, "|", "\\|")

--- a/fs/write_test.go
+++ b/fs/write_test.go
@@ -67,3 +67,24 @@ func TestWriteMarkdownTable(t *testing.T) {
 	assert.Equal(t, "| --- | --- |", lines[1])
 	assert.Contains(t, got, "| Acme | 9 |")
 }
+
+// TestSanitizeFilename covers names built from row data, which may contain
+// anything a model emitted — path separators would silently redirect the file.
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"locked-out.md", "locked-out.md"},
+		{"a/b:c", "a_b_c"},
+		{`a\b`, "a_b"},
+		{"tab\there", "tab_here"},
+		{"  padded  ", "padded"},
+		{"", ""},
+		{"   ", ""},
+		{"...", ""},
+		{"___", ""},
+		{"Any plans for dark mode?", "Any plans for dark mode?"},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, SanitizeFilename(tc.in), "input %q", tc.in)
+	}
+}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -204,3 +204,39 @@ func TestRun_RerunReusesOutputFolder(t *testing.T) {
 	assert.Len(t, readOutputLines(t, filepath.Join(outputFolder, "gen.jsonl")), 2,
 		"the file must hold one run's rows, not both runs appended")
 }
+
+// TestRun_PerRowWritePipeline is the end-to-end folder-of-documents case: read
+// rows, generate a body per row, and emit one file per row rather than a table.
+func TestRun_PerRowWritePipeline(t *testing.T) {
+	srv := llmtest.NewServer(t,
+		`{"slug":"alpha","body":"Alpha body."}`,
+		`{"slug":"beta","body":"Beta body."}`)
+
+	srcDir := t.TempDir() // input files live apart from the output folder
+	seeds := filepath.Join(srcDir, "seeds.csv")
+	require.NoError(t, os.WriteFile(seeds, []byte("topic\nAlpha\nBeta\n"), 0o644))
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = t.TempDir()
+	cfg.Version = "1.0"
+	cfg.Steps = []config.Step{
+		{Name: "seeds", Read: seeds},
+		{
+			Name: "articles", Model: "ollama:test-model", ForEach: "seeds",
+			Prompt:        "Write about {{.item.topic}}",
+			JSONSchemaRaw: `{"type":"object","properties":{"slug":{"type":"string"},"body":{"type":"string"}},"required":["slug","body"],"additionalProperties":false}`,
+			ModelConfig:   config.ModelConfig{BaseURL: srv.URL},
+		},
+		{Name: "files", ForEach: "articles", Write: "docs/{{.item.slug}}.md", Content: "{{.item.body}}"},
+	}
+
+	require.NoError(t, utils.PreprocessConfig(cfg))
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, runner.NewRunner(cfg).Run(context.Background()))
+
+	for slug, want := range map[string]string{"alpha": "Alpha body.", "beta": "Beta body."} {
+		data, err := os.ReadFile(filepath.Join(cfg.OutputFolder, "docs", slug+".md"))
+		require.NoError(t, err, "expected one file per row")
+		assert.Equal(t, want, string(data))
+	}
+}

--- a/step/write_step.go
+++ b/step/write_step.go
@@ -5,19 +5,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/mirpo/datamatic/config"
 	"github.com/mirpo/datamatic/fs"
 	"github.com/mirpo/datamatic/jsonl"
+	"github.com/mirpo/datamatic/promptbuilder"
 	"github.com/rs/zerolog/log"
 )
 
 type WriteStep struct{}
 
-// Run exports a source step's rows to a single file in the configured format
-// (csv / json / md / jsonl). It is terminal — it reads the source's JSONL and
-// writes the deliverable; it does not produce pipeline rows itself.
+// Run exports a source step's rows to a file. With `from:` it writes one
+// aggregate file in the configured format (csv / json / md / jsonl); with
+// `forEach:` it writes one file per row (see runPerRow). Either way the step is
+// terminal: it reads the source's JSONL and produces no pipeline rows itself.
 func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Step, outputFolder string) error {
+	if step.ForEach != "" {
+		return p.runPerRow(ctx, cfg, step)
+	}
+
 	src := cfg.GetStepByName(step.From)
 	if src == nil {
 		return fmt.Errorf("'from' references unknown step '%s'", step.From)
@@ -41,34 +49,179 @@ func (p *WriteStep) Run(ctx context.Context, cfg *config.Config, step config.Ste
 		return fmt.Errorf("step '%s': %w", step.Name, err)
 	}
 
-	switch step.Format {
-	case config.WriteFormatJSON:
-		if err := fs.WriteJSONArray(step.Write, rows); err != nil {
-			return err
-		}
-	case config.WriteFormatJSONL:
-		if err := writeJSONL(step.Write, rows); err != nil {
-			return err
-		}
-	case config.WriteFormatCSV, config.WriteFormatMarkdown:
-		objs, err := asObjects(rows)
-		if err != nil {
-			return fmt.Errorf("step '%s': %w", step.Name, err)
-		}
-		// WriteCSV and WriteMarkdownTable share a signature — pick by format
-		writeTable := fs.WriteCSV
-		if step.Format == config.WriteFormatMarkdown {
-			writeTable = fs.WriteMarkdownTable
-		}
-		if err := writeTable(step.Write, objs); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("step '%s': unknown write format '%s'", step.Name, step.Format)
+	if err := serializeRows(step.Format, step.Write, rows); err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
 	}
 
 	log.Info().Msgf("write exported %d rows to %s", len(rows), step.Write)
 	return nil
+}
+
+// runPerRow writes one file per source row: the `write:` path is a template
+// rendered against the row (so the row's own fields name the file), and
+// `content:` — when set — is the file body, written as raw text rather than
+// serialized. This is the "folder of documents" mode, next to the aggregate
+// "one table" mode.
+func (p *WriteStep) runPerRow(ctx context.Context, cfg *config.Config, step config.Step) error {
+	src := cfg.GetStepByName(step.ForEach)
+	if src == nil {
+		return fmt.Errorf("'forEach' references unknown step '%s'", step.ForEach)
+	}
+
+	file, err := os.Open(src.OutputFilename)
+	if err != nil {
+		return fmt.Errorf("step '%s': failed to open source '%s': %w", step.Name, src.OutputFilename, err)
+	}
+	defer file.Close()
+
+	rows, err := collectRows(ctx, *src, file)
+	if err != nil {
+		return fmt.Errorf("step '%s': %w", step.Name, err)
+	}
+
+	// step.OutputFilename carries the output folder for per-row writes: the
+	// path itself can only be resolved once rendered
+	written := map[string]int{}
+
+	for i, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		pb, err := rowBuilder(step, src.Name, row)
+		if err != nil {
+			return fmt.Errorf("step '%s': %w", step.Name, err)
+		}
+
+		// the path is rendered from a copy of the row whose values are already
+		// filename-safe, so a slash written in the template still nests while a
+		// slash inside the data cannot redirect the file
+		pathBuilder, err := rowBuilder(step, src.Name, sanitizeForPath(row))
+		if err != nil {
+			return fmt.Errorf("step '%s': %w", step.Name, err)
+		}
+
+		path, err := renderRowPath(pathBuilder, step, i)
+		if err != nil {
+			return fmt.Errorf("step '%s' row %d: %w", step.Name, i, err)
+		}
+		path = uniquePath(path, written)
+
+		if err := fs.EnsureFolder(filepath.Dir(path)); err != nil {
+			return fmt.Errorf("step '%s': %w", step.Name, err)
+		}
+
+		if step.Content != "" {
+			body, err := pb.RenderString(step.Content)
+			if err != nil {
+				return fmt.Errorf("step '%s' row %d: failed to render content: %w", step.Name, i, err)
+			}
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				return fmt.Errorf("step '%s': failed to write '%s': %w", step.Name, path, err)
+			}
+		} else if err := serializeRows(step.Format, path, rows[i:i+1]); err != nil {
+			return fmt.Errorf("step '%s' row %d: %w", step.Name, i, err)
+		}
+	}
+
+	log.Info().Msgf("write exported %d rows to %d file(s) under %s", len(rows), len(written), step.OutputFilename)
+	return nil
+}
+
+// rowBuilder binds one source row to the step's templates, exposing it both as
+// {{.item}} and under the source step's own name.
+func rowBuilder(step config.Step, sourceName string, row interface{}) (*promptbuilder.PromptBuilder, error) {
+	pb, err := promptbuilder.NewPromptBuilder(step.Write, step.ForEach, step.Content)
+	if err != nil {
+		return nil, err
+	}
+	pb.AddValue("-", sourceName, "", row)
+	return pb, nil
+}
+
+// sanitizeForPath returns a copy of a row whose every string is safe as a single
+// path segment, so values interpolated into a write path cannot introduce
+// directories. Non-strings are untouched.
+func sanitizeForPath(v interface{}) interface{} {
+	switch t := v.(type) {
+	case string:
+		return fs.SanitizeFilename(t)
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, val := range t {
+			out[k] = sanitizeForPath(val)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, val := range t {
+			out[i] = sanitizeForPath(val)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// renderRowPath renders the write template for one row into a path under the
+// output folder. A template may nest (e.g. "{{.item.kind}}/{{.item.id}}.md");
+// a file name that renders to nothing falls back to the row number.
+func renderRowPath(pb *promptbuilder.PromptBuilder, step config.Step, i int) (string, error) {
+	rendered, err := pb.RenderString(step.Write)
+	if err != nil {
+		return "", fmt.Errorf("failed to render write path: %w", err)
+	}
+
+	dir, name := filepath.Split(rendered)
+	ext := filepath.Ext(name)
+	stem := fs.SanitizeFilename(strings.TrimSuffix(name, ext))
+	if stem == "" {
+		stem = strconv.Itoa(i + 1)
+	}
+	name = stem + ext
+
+	if filepath.IsAbs(rendered) {
+		return filepath.Join(dir, name), nil
+	}
+	return filepath.Join(step.OutputFilename, dir, name), nil
+}
+
+// uniquePath keeps two rows that render the same name from clobbering each
+// other within a run, by numbering the later ones. Leftovers from previous runs
+// are still overwritten — each run produces a fresh set of files.
+func uniquePath(path string, written map[string]int) string {
+	written[path]++
+	if n := written[path]; n > 1 {
+		ext := filepath.Ext(path)
+		numbered := fmt.Sprintf("%s-%d%s", strings.TrimSuffix(path, ext), n, ext)
+		log.Warn().Msgf("two rows render the same file name, writing '%s' instead of overwriting '%s'", numbered, path)
+		return numbered
+	}
+	return path
+}
+
+// serializeRows writes rows to one file in the given format. Shared by the
+// aggregate mode (every row) and the per-row mode (a single row per file).
+func serializeRows(format, path string, rows []interface{}) error {
+	switch format {
+	case config.WriteFormatJSON:
+		return fs.WriteJSONArray(path, rows)
+	case config.WriteFormatJSONL:
+		return writeJSONL(path, rows)
+	case config.WriteFormatCSV, config.WriteFormatMarkdown:
+		objs, err := asObjects(rows)
+		if err != nil {
+			return err
+		}
+		// WriteCSV and WriteMarkdownTable share a signature — pick by format
+		writeTable := fs.WriteCSV
+		if format == config.WriteFormatMarkdown {
+			writeTable = fs.WriteMarkdownTable
+		}
+		return writeTable(path, objs)
+	default:
+		return fmt.Errorf("unknown write format '%s'", format)
+	}
 }
 
 // asObjects asserts every row is a JSON object (required for csv/md columns).

--- a/step/write_step_test.go
+++ b/step/write_step_test.go
@@ -95,3 +95,66 @@ func TestWriteStepRun_NonObjectRowFailsCSV(t *testing.T) {
 	err := (&WriteStep{}).Run(context.Background(), cfg, step, dir)
 	require.Error(t, err, "csv needs object rows")
 }
+
+// perRowSetup runs a per-row write step over the given JSONL source rows and
+// returns the directory the files landed in.
+func perRowSetup(t *testing.T, srcLines, writeTmpl, content, format string) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.jsonl")
+	require.NoError(t, os.WriteFile(srcPath, []byte(srcLines), 0o644))
+
+	cfg := config.NewConfig()
+	cfg.OutputFolder = dir
+	cfg.Steps = []config.Step{{Name: "data", Type: config.TransformStepType, OutputFilename: srcPath}}
+	step := config.Step{
+		Name: "files", Type: config.WriteStepType, ForEach: "data",
+		Write: writeTmpl, Content: content, Format: format, OutputFilename: dir,
+	}
+
+	require.NoError(t, (&WriteStep{}).Run(context.Background(), cfg, step, dir))
+	return dir
+}
+
+func TestWriteStepRun_PerRowContent(t *testing.T) {
+	dir := perRowSetup(t,
+		`{"id":"alpha","body":"first draft"}`+"\n"+`{"id":"beta","body":"second draft"}`+"\n",
+		"drafts/{{.item.id}}.md", "{{.item.body}}", "")
+
+	for name, want := range map[string]string{"alpha.md": "first draft", "beta.md": "second draft"} {
+		data, err := os.ReadFile(filepath.Join(dir, "drafts", name))
+		require.NoError(t, err, "expected one file per row")
+		assert.Equal(t, want, string(data), "body is the rendered content, not JSON")
+	}
+}
+
+func TestWriteStepRun_PerRowSanitizesAndDedupes(t *testing.T) {
+	dir := perRowSetup(t,
+		`{"id":"a/b","body":"one"}`+"\n"+`{"id":"a/b","body":"two"}`+"\n"+`{"id":"","body":"three"}`+"\n",
+		"{{.item.id}}.txt", "{{.item.body}}", "")
+
+	assert.FileExists(t, filepath.Join(dir, "a_b.txt"), "separators in the name are replaced")
+	assert.FileExists(t, filepath.Join(dir, "a_b-2.txt"), "a colliding name gets a suffix instead of clobbering")
+	assert.FileExists(t, filepath.Join(dir, "3.txt"), "an empty name falls back to the row number")
+}
+
+func TestWriteStepRun_PerRowSerializesWithoutContent(t *testing.T) {
+	dir := perRowSetup(t,
+		`{"id":"alpha","score":7}`+"\n",
+		"{{.item.id}}.json", "", config.WriteFormatJSON)
+
+	data, err := os.ReadFile(filepath.Join(dir, "alpha.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"score": 7`, "without content the row itself is serialized")
+}
+
+func TestWriteStepRun_PerRowUnknownSourceFails(t *testing.T) {
+	cfg := config.NewConfig()
+	step := config.Step{
+		Name: "files", Type: config.WriteStepType, ForEach: "ghost",
+		Write: "{{.item.id}}.txt", Content: "x", OutputFilename: t.TempDir(),
+	}
+	err := (&WriteStep{}).Run(context.Background(), cfg, step, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}

--- a/utils/preprocess.go
+++ b/utils/preprocess.go
@@ -162,6 +162,9 @@ func PreprocessConfig(cfg *config.Config) error {
 		if step.Format != "" && step.Type != config.ReadStepType && step.Type != config.WriteStepType {
 			return fmt.Errorf("step '%s': 'format' is only valid on read and write steps", step.Name)
 		}
+		if step.Content != "" && step.Type != config.WriteStepType {
+			return fmt.Errorf("step '%s': 'content' is only valid on write steps", step.Name)
+		}
 		// a write step is terminal — it produces a deliverable file, not pipeline
 		// rows — so it may not be used as a source
 		for _, ref := range []struct{ field, name string }{{"from", step.From}, {"forEach", step.ForEach}} {
@@ -221,23 +224,14 @@ func PreprocessConfig(cfg *config.Config) error {
 			}
 		}
 
-		// Write steps: terminal export of a source step's rows to a file. The
-		// deliverable is generated output, so a relative path joins the output
-		// folder (an absolute path publishes outside it).
+		// Write steps: terminal export of a source step's rows. `from:` writes
+		// one aggregate file, `forEach:` writes one file per row. The deliverable
+		// is generated output, so a relative path joins the output folder (an
+		// absolute path publishes outside it).
 		if step.Type == config.WriteStepType {
-			if step.From == "" {
-				return fmt.Errorf("step '%s': 'from' is required for write steps", step.Name)
-			}
-			if err := requireEarlierStep(stepNames, "from", step.From); err != nil {
+			if err := setWriteStepMode(step, cfg.OutputFolder, stepNames); err != nil {
 				return fmt.Errorf("step '%s': %w", step.Name, err)
 			}
-			step.Write = resolveOutputPath(cfg.OutputFolder, step.Write)
-			format, err := resolveWriteFormat(step)
-			if err != nil {
-				return fmt.Errorf("step '%s': %w", step.Name, err)
-			}
-			step.Format = format
-			step.OutputFilename = step.Write
 		}
 
 		if err := validateIterationSettings(step, stepNames); err != nil {
@@ -363,6 +357,64 @@ func getFullOutputPath(step config.Step, outputFolder string) (string, error) {
 	return filepath.Clean(fullPath), nil
 }
 
+// setWriteStepMode validates a write step and resolves its output. Exactly one
+// source is required and it picks the mode: `from:` exports every row into one
+// aggregate file, `forEach:` renders the path per row and writes one file each.
+func setWriteStepMode(step *config.Step, outputFolder string, stepNames map[string]bool) error {
+	perRow := step.ForEach != ""
+	if perRow == (step.From != "") {
+		return errors.New("exactly one of 'from' or 'forEach' is required for write steps")
+	}
+
+	source, field := step.From, "from"
+	if perRow {
+		source, field = step.ForEach, "forEach"
+	}
+	if err := requireEarlierStep(stepNames, field, source); err != nil {
+		return err
+	}
+
+	if !perRow && step.Content != "" {
+		return errors.New("'content' is only valid on a per-row write step (one using 'forEach')")
+	}
+
+	format, err := resolveWriteFormat(step)
+	if perRow {
+		// no format needed when content: supplies the body verbatim — the
+		// extension is then just part of the file name (.txt, .md, .eml)
+		if step.Content == "" && err != nil {
+			return fmt.Errorf("%w; add 'content' to write the file body as raw text instead", err)
+		}
+		return setPerRowWriteTemplate(step, outputFolder, format)
+	}
+	if err != nil {
+		return err
+	}
+
+	step.Format = format
+	step.Write = resolveOutputPath(outputFolder, step.Write)
+	step.OutputFilename = step.Write
+	return nil
+}
+
+// setPerRowWriteTemplate keeps the write path as a template — it is rendered per
+// row at runtime — while resolving everything that can be settled up front.
+func setPerRowWriteTemplate(step *config.Step, outputFolder, format string) error {
+	if !strings.Contains(step.Write, "{{") {
+		return fmt.Errorf("a per-row 'write' path must contain a template (e.g. '{{.item.id}}.md'), otherwise every row overwrites '%s'", step.Write)
+	}
+
+	// parse both templates now so a typo fails at config time, not mid-run
+	if _, err := promptbuilder.NewPromptBuilder(step.Write, step.ForEach, step.Content); err != nil {
+		return err
+	}
+
+	step.Format = format
+	// the path is resolved per row, once rendered; remember the base to join to
+	step.OutputFilename = outputFolder
+	return nil
+}
+
 // resolveDataPath makes a relative input path relative to the config file's
 // directory, so a workflow's data files travel with it and it runs from any
 // working directory. Absolute paths are left unchanged.
@@ -458,6 +510,14 @@ func requireEarlierStep(stepNames map[string]bool, field, name string) error {
 // counts themselves are resolved at runtime by the runner.
 func validateIterationSettings(step *config.Step, stepNames map[string]bool) error {
 	if step.Type != config.PromptStepType {
+		// write steps use forEach too, to emit one file per source row; that
+		// mode is validated in setWriteStepMode
+		if step.Type == config.WriteStepType {
+			if step.Count != 0 {
+				return fmt.Errorf("'count' is only valid on prompt steps")
+			}
+			return nil
+		}
 		if step.Count != 0 || step.ForEach != "" {
 			return fmt.Errorf("'count' and 'forEach' are only valid on prompt steps")
 		}

--- a/utils/preprocess_test.go
+++ b/utils/preprocess_test.go
@@ -651,10 +651,10 @@ func TestPreprocessConfig_WriteStep(t *testing.T) {
 		assert.Equal(t, config.WriteStepType, cfg.Steps[1].Type)
 		assert.Equal(t, config.WriteFormatCSV, cfg.Steps[1].Format)
 	})
-	t.Run("missing from fails", func(t *testing.T) {
+	t.Run("missing source fails", func(t *testing.T) {
 		cfg := base()
 		cfg.Steps[1].From = ""
-		assert.ErrorContains(t, PreprocessConfig(cfg), "'from' is required")
+		assert.ErrorContains(t, PreprocessConfig(cfg), "exactly one of 'from' or 'forEach'")
 	})
 	t.Run("unknown extension without format fails", func(t *testing.T) {
 		cfg := base()
@@ -681,6 +681,85 @@ func TestPreprocessConfig_WriteStep(t *testing.T) {
 		cfg := base()
 		cfg.Steps[0].Format = "csv"
 		assert.ErrorContains(t, PreprocessConfig(cfg), "'format' is only valid on read and write")
+	})
+}
+
+// TestPreprocessConfig_PerRowWrite covers the second write mode: forEach makes a
+// write step emit one file per source row, with the path as a per-row template
+// and an optional content: template supplying the raw body.
+func TestPreprocessConfig_PerRowWrite(t *testing.T) {
+	base := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.OutputFolder = t.TempDir()
+		cfg.Steps = []config.Step{
+			{Name: "gen", Prompt: "p", Model: "ollama:m", Count: 2},
+			{Name: "files", ForEach: "gen", Write: "out/{{.item.id}}.txt", Content: "{{.item.body}}"},
+		}
+		return cfg
+	}
+
+	t.Run("valid per-row write", func(t *testing.T) {
+		cfg := base()
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.WriteStepType, cfg.Steps[1].Type)
+		assert.Equal(t, "out/{{.item.id}}.txt", cfg.Steps[1].Write,
+			"the path stays a template — it is rendered per row at runtime")
+	})
+
+	t.Run("both from and forEach fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].From = "gen"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "exactly one of 'from' or 'forEach'")
+	})
+
+	t.Run("neither from nor forEach fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].ForEach = ""
+		assert.ErrorContains(t, PreprocessConfig(cfg), "exactly one of 'from' or 'forEach'")
+	})
+
+	t.Run("per-row path without a template fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Write = "out/same.txt"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "must contain a template")
+	})
+
+	t.Run("malformed template fails at config time", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Write = "out/{{.item.id.txt"
+		assert.Error(t, PreprocessConfig(cfg))
+	})
+
+	t.Run("content on an aggregate write fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1] = config.Step{Name: "files", From: "gen", Write: "out.csv", Content: "{{.gen.body}}"}
+		assert.ErrorContains(t, PreprocessConfig(cfg), "'content' is only valid")
+	})
+
+	t.Run("content on a prompt step fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[0].Content = "x"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "'content' is only valid")
+	})
+
+	t.Run("raw-text extension without content fails", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Content = ""
+		assert.ErrorContains(t, PreprocessConfig(cfg), "content")
+	})
+
+	t.Run("content-less per-row serializes by extension", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].Content = ""
+		cfg.Steps[1].Write = "out/{{.item.id}}.json"
+		require.NoError(t, PreprocessConfig(cfg))
+		assert.Equal(t, config.WriteFormatJSON, cfg.Steps[1].Format)
+	})
+
+	t.Run("forEach source must be an earlier step", func(t *testing.T) {
+		cfg := base()
+		cfg.Steps[1].ForEach = "ghost"
+		assert.ErrorContains(t, PreprocessConfig(cfg), "ghost")
 	})
 }
 


### PR DESCRIPTION
## Summary
A write step's source now picks its mode: `from:` writes **one file with every row** (a dataset or report — today's behavior), `forEach:` writes **one file per row** (a folder of documents). That closes the content half of the office loop — N rows → N documents, next to N rows → 1 table.

```yaml
  - name: reply_digest
    from: drafts                          # → one replies.md table of all drafts
    write: replies.md

  - name: reply_files
    forEach: drafts                       # → one file per draft
    write: replies/{{.item.subject}}.md   # path is a template, rendered per row
    content: "{{.item.reply}}"            # body is raw text, not JSON
```

- **`content:`** is the file body as raw text — that is what makes the output a *document* rather than a record. Omit it and the single row is serialized by extension instead (`.json`, `.csv`, …), one row per file, reusing the same writers as aggregate mode.
- The path template may nest (`out/{{.item.kind}}/{{.item.id}}.md`); missing directories are created.
- Exactly one of `from`/`forEach` is now required on a write step, and a per-row path without a template is rejected — otherwise every row would overwrite the same file. Both templates are parsed at config time so a typo fails in `validate`, not mid-run.

## Filename safety, split by origin
A path rendered from model output is a real hazard, so slashes are treated differently depending on where they come from: the path is rendered against a **copy of the row whose strings are already filename-safe**, so a slash you write in the *template* still nests directories, while a slash inside the *data* cannot redirect the file.

This came out of a failing test — sanitizing the final path segment (the original plan) is too late, because `filepath.Split` has already turned a data slash into a directory.

Also: a name that renders empty falls back to the row number, and two rows rendering the same name get numbered (`-2`) with a warning rather than silently clobbering each other.

## Commits
1. `feat:` config for per-row write steps (forEach + content)
2. `feat:` `fs.SanitizeFilename` — both slash kinds replaced regardless of platform, so a name written on one OS cannot escape its directory on another
3. `feat:` per-row fan-out in the write step (+ extracted `serializeRows`, shared by both modes)
4. `test:` e2e per-row pipeline
5. `docs:` inbox-triage emits per-row reply drafts + README

## Verification
- Full `go test ./...` + `golangci-lint` green; `datamatic validate` passes on every example.
- New tests cover: all 10 config/guard cases, the sanitizer, per-row content bodies, sanitize+collision+empty-name fallback, content-less serialization, and an end-to-end read → LLM → folder-of-documents run.
- Live-run on Ollama (`qwen3:1.7b`): `write exported 4 rows to 4 file(s)`, `dataset/replies/` holding one file per ticket named from its subject (including one with spaces and a comma), each body the reply text — alongside the aggregate `board.csv` and `replies.md`.